### PR TITLE
docs: clarify test classification in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,4 +230,4 @@ cargo run -p webfetch-cli -- --url https://example.com --as-markdown
 cargo run -p webfetch-cli -- mcp
 ```
 
-Integration tests use `wiremock` for HTTP mocking. See `specs/initial.md` for test requirements.
+Tests use `wiremock` for HTTP mocking (no real external network calls). See `specs/initial.md` for test requirements.


### PR DESCRIPTION
## What
Clarify test terminology in AGENTS.md - remove "integration" qualifier and add note about no external network calls.

## Why
The previous wording "Integration tests use wiremock for HTTP mocking" was confusing - integration tests typically imply real integrations without mocks. Since wiremock mocks all external HTTP, calling them just "tests" is more accurate.

## How
- Changed "Integration tests" → "Tests"
- Added "(no real external network calls)" to clarify what wiremock provides

## Risk
- Low
- Documentation only change

### Checklist
- [x] Documentation is updated
- [x] No code changes