### PR TITLE
chore(release): prepare v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-02-12
+
+### Highlights
+
+- Updated dependencies to latest versions
+- Added maintenance spec for periodic upkeep
+- Documentation improvements
+
+### What's Changed
+
+* chore: periodic maintenance - update deps, docs, and add maintenance spec ([#15](https://github.com/everruns/fetchkit/pull/15)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/fetchkit/compare/v0.1.0...v0.1.1
+
 ## [0.1.0] - 2026-02-12
 
 ### Highlights
@@ -30,5 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/everruns/fetchkit/commits/v0.1.0
 
-[Unreleased]: https://github.com/everruns/fetchkit/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/everruns/fetchkit/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/everruns/fetchkit/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/everruns/fetchkit/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fetchkit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "fetchkit-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "fetchkit",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "fetchkit-python"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fetchkit",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/fetchkit-cli/Cargo.toml
+++ b/crates/fetchkit-cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "fetchkit"
 path = "src/main.rs"
 
 [dependencies]
-fetchkit = { path = "../fetchkit", version = "0.1.0" }
+fetchkit = { path = "../fetchkit", version = "0.1.1" }
 tokio = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## What
Patch release v0.1.1 — bumps version and updates CHANGELOG.

## Why
Ship the periodic maintenance changes (dependency updates, docs improvements, maintenance spec) as a patch release.

## How
- Bumped workspace version 0.1.0 → 0.1.1 in root Cargo.toml
- Updated fetchkit dependency version in fetchkit-cli/Cargo.toml
- Added v0.1.1 section to CHANGELOG.md with highlights and change list

## Risk
- Low
- Version bump only; no code changes

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict

https://claude.ai/code/session_01Uhzv81dN2M8zqGVJUnKhGY