### PR TITLE
chore(release): prepare v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-02-16
+
+### Highlights
+
+- Added SSRF protection with safe-by-default DNS resolution policy
+- Private/reserved IP ranges are now blocked by default to prevent server-side request forgery
+
+### What's Changed
+
+* feat(security)!: add SSRF protection with safe-by-default DNS policy ([#17](https://github.com/everruns/fetchkit/pull/17))
+
+**Full Changelog**: https://github.com/everruns/fetchkit/compare/v0.1.1...v0.1.2
+
 ## [0.1.1] - 2026-02-12
 
 ### Highlights
@@ -44,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/everruns/fetchkit/commits/v0.1.0
 
-[Unreleased]: https://github.com/everruns/fetchkit/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/everruns/fetchkit/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/everruns/fetchkit/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/everruns/fetchkit/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/everruns/fetchkit/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/fetchkit-cli/Cargo.toml
+++ b/crates/fetchkit-cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "fetchkit"
 path = "src/main.rs"
 
 [dependencies]
-fetchkit = { path = "../fetchkit", version = "0.1.1" }
+fetchkit = { path = "../fetchkit", version = "0.1.2" }
 tokio = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## What
Release v0.1.2 patch version.

## Why
New patch release including SSRF protection with safe-by-default DNS policy.

## How
- Bumped workspace version from 0.1.1 to 0.1.2
- Updated fetchkit-cli dependency version to match
- Updated CHANGELOG.md with v0.1.2 entry

## Changes included since v0.1.1
- feat(security)!: add SSRF protection with safe-by-default DNS policy (#17)

## Risk
- Low
- Version bump and changelog only

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict

https://claude.ai/code/session_018ri3p7jrvdbxfJtWNqasYm