### PR TITLE
chore: add attribution settings and agent attribution policy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ Telegraph. Drop filler/grammar. Min tokens (global AGENTS + replies).
 Critical Thinking
 Fix root cause (not band-aid). Unsure: read more code; if still stuck, ask w/ short options. Unrecognized changes: assume other agent; keep going; focus your changes. If it causes issues, stop + ask user. Leave breadcrumb notes in thread.
 
+Attribution
+NEVER add links to Claude sessions in PR body or commits. Also never attribute commit or merge commit to coding agents, always use real user.
+
 ### Principles
 
 - Keep decisions as comments on top of the file. Only important decisions that could not be inferred from code.


### PR DESCRIPTION
## What
Add .claude/settings.json with empty attribution fields and add attribution policy to AGENTS.md.

## Why
Prevent coding agents from adding session links to commits/PRs and ensure commits are attributed to real users.

## How
- Created .claude/settings.json with empty commit and pr attribution strings
- Added Attribution section to AGENTS.md with clear rules

## Risk
- Low
- Config-only change, no code affected

### Checklist
- [x] No code changes, config only
- [x] Documentation updated (AGENTS.md)