### PR TITLE
docs: add cargo install from crates.io to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ AI-friendly web content fetching tool designed for LLM consumption. Rust library
 
 ## Installation
 
-### From Git (recommended)
+### From crates.io (recommended)
+
+```bash
+cargo install fetchkit-cli
+```
+
+### From Git
 
 ```bash
 cargo install --git https://github.com/everruns/fetchkit fetchkit-cli
@@ -88,7 +94,7 @@ Add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-fetchkit = { git = "https://github.com/everruns/fetchkit" }
+fetchkit = "0.2"
 ```
 
 ### Basic Fetch


### PR DESCRIPTION
## What
Update README installation instructions to recommend `cargo install fetchkit-cli` from crates.io as the primary installation method. Update library dependency example to use crates.io version.

## Why
fetchkit is now published on crates.io, so users can install directly without needing the git URL.

## How
- Added "From crates.io (recommended)" section with `cargo install fetchkit-cli`
- Demoted "From Git" to secondary option (removed "recommended" label)
- Changed library dependency from `{ git = "..." }` to `"0.2"`

## Risk
- Low
- Documentation only, no code changes

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict