### PR TITLE
fix(cli): disable bin rustdoc to avoid doc collision

### DIFF
--- a/crates/fetchkit-cli/Cargo.toml
+++ b/crates/fetchkit-cli/Cargo.toml
@@ -11,8 +11,10 @@ categories.workspace = true
 readme = "../../README.md"
 
 [[bin]]
+# Keep CLI docs off so rustdoc doesn't collide with the library's `fetchkit` output.
 name = "fetchkit"
 path = "src/main.rs"
+doc = false
 
 [dependencies]
 fetchkit = { path = "../fetchkit", version = "0.1.2" }


### PR DESCRIPTION
## What
Disable rustdoc for the `fetchkit` binary target in `fetchkit-cli`.

## Why
`cargo doc --workspace --no-deps` warned about an output filename collision because both the library target and CLI binary target generated docs at `target/doc/fetchkit/index.html`.

## How
Add `doc = false` to the CLI `[[bin]]` target and document the reason inline.

## Risk
- Low
- Only affects rustdoc generation for the CLI binary target
- Keeps the installed executable name unchanged

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict
- [x] `cargo fmt --all --check` passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` passed
- [ ] `cargo build --workspace` passed locally (blocked by existing `fetchkit-python` Python-link env issue on this machine)
