### PR TITLE
docs: add git user config requirement to attribution section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,13 @@ Fix root cause (not band-aid). Unsure: read more code; if still stuck, ask w/ sh
 Attribution
 NEVER add links to Claude sessions in PR body or commits. Also never attribute commit or merge commit to coding agents, always use real user.
 
+Before committing, configure git user from environment variables:
+```bash
+git config user.name "$GIT_USER_NAME"
+git config user.email "$GIT_USER_EMAIL"
+```
+`GIT_USER_NAME` and `GIT_USER_EMAIL` must be set in the session.
+
 ### Principles
 
 - Keep decisions as comments on top of the file. Only important decisions that could not be inferred from code.


### PR DESCRIPTION
## What
Add git user configuration requirement to the Attribution section in AGENTS.md.

## Why
Agents must configure `git user.name` and `git user.email` from environment variables (`GIT_USER_NAME`, `GIT_USER_EMAIL`) before committing to ensure commits are properly attributed to the real user, not the agent.

## How
Added a code snippet and note to the existing Attribution section in AGENTS.md.

## Risk
- Low
- Documentation-only change, no code impact

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict