### PR TITLE
fix: resolve threat model issues

### DIFF
--- a/crates/fetchkit/src/convert.rs
+++ b/crates/fetchkit/src/convert.rs
@@ -64,7 +64,7 @@ pub fn html_to_markdown(html: &str) -> String {
                 tag_lower.split_whitespace().next().unwrap_or("")
             };
 
-            // Handle skip elements
+            // THREAT[TM-CONV-001]: Strip script/style/iframe/svg to prevent injection
             let skip_tags = ["script", "style", "noscript", "iframe", "svg"];
             if skip_tags.contains(&tag_name) {
                 if is_closing {
@@ -255,7 +255,7 @@ pub fn html_to_text(html: &str) -> String {
                 tag_lower.split_whitespace().next().unwrap_or("")
             };
 
-            // Handle skip elements
+            // THREAT[TM-CONV-001]: Strip script/style/iframe/svg to prevent injection
             let skip_tags = ["script", "style", "noscript", "iframe", "svg"];
             if skip_tags.contains(&tag_name) {
                 if is_closing {
@@ -324,6 +324,7 @@ fn extract_attribute(tag: &str, attr: &str) -> Option<String> {
 }
 
 /// Decode HTML entity starting from ampersand
+// THREAT[TM-CONV-004]: Limited named-entity set; rejects long/unknown sequences
 fn decode_entity(c: char, chars: &mut std::iter::Peekable<std::str::Chars>) -> char {
     if c != '&' {
         return c;

--- a/crates/fetchkit/src/fetchers/default.rs
+++ b/crates/fetchkit/src/fetchers/default.rs
@@ -36,10 +36,10 @@ const BINARY_PREFIXES: &[&str] = &[
     "font/",
 ];
 
-/// First-byte timeout (connect + first response byte)
+// THREAT[TM-DOS-002]: First-byte timeout prevents slowloris / slow-start attacks
 const FIRST_BYTE_TIMEOUT: Duration = Duration::from_secs(1);
 
-/// Body timeout (total)
+// THREAT[TM-DOS-002]: Body timeout caps total request duration
 const BODY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Truncation message appended when body is cut short (timeout or size limit)
@@ -360,6 +360,7 @@ fn build_client_for_url(
     headers: HeaderMap,
     options: &FetchOptions,
 ) -> Result<reqwest::Client, FetchError> {
+    // THREAT[TM-NET-003]: New client per request prevents connection-pool state leakage
     let mut client_builder = reqwest::Client::builder()
         .default_headers(headers)
         .connect_timeout(FIRST_BYTE_TIMEOUT)

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -157,7 +157,7 @@ redirect target, not the original host.
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
-| TM-NET-001 | HTTP downgrade (HTTPS URL redirects to HTTP) | Medium | No scheme validation on redirects; reqwest follows | **ACCEPTED** |
+| TM-NET-001 | HTTP downgrade (HTTPS URL redirects to HTTP) | Medium | Scheme validated per hop (non-HTTP blocked); HTTPS→HTTP downgrade allowed | **ACCEPTED** |
 | TM-NET-002 | TLS certificate validation bypass | Low | Uses reqwest defaults (system certificate store via rustls-platform-verifier) | MITIGATED |
 | TM-NET-003 | Connection reuse leaking context | Low | New reqwest client per request; no connection pooling across requests | MITIGATED |
 | TM-NET-004 | Proxy environment variables (HTTP_PROXY) | Medium | Reqwest respects system proxy env vars; attacker could set these in container | **CALLER RISK** |
@@ -166,8 +166,9 @@ redirect target, not the original host.
 ### Mitigation Details
 
 **TM-NET-001 — HTTP downgrade (ACCEPTED):**
-FetchKit allows both HTTP and HTTPS schemes. If an HTTPS URL redirects to HTTP,
-reqwest will follow the redirect without warning. This is accepted because:
+FetchKit validates the scheme at each redirect hop — non-HTTP(S) schemes are
+rejected (see TM-INPUT-001). However, HTTPS→HTTP downgrade is still allowed.
+This is accepted because:
 - FetchKit is designed for content fetching, not security-sensitive operations
 - The caller controls which URLs to fetch
 - Enforcing HTTPS-only would break many legitimate use cases
@@ -218,7 +219,6 @@ URLs like `http://evil.com@127.0.0.1/path` have `127.0.0.1` as the host (with
 `evil.com` as the username). The `url` crate correctly parses this, and
 resolve-then-check validates the actual host's IP.
 
-<<<<<<< HEAD
 **TM-INPUT-007 — String-based prefix matching (MITIGATED):**
 Prefix matching now parses both the URL and the prefix with the `url` crate,
 then compares scheme, host (exact match), port, and path (segment-boundary


### PR DESCRIPTION
## What
Fix three issues in the threat model spec and add missing THREAT code comments.

## Why
- specs/threat-model.md had a stale merge conflict marker corrupting the file
- TM-NET-001 description claimed no scheme validation on redirects but scheme validation exists at each redirect hop since the manual-redirect refactoring
- Several mitigated threats (TM-DOS-002, TM-NET-003, TM-CONV-001, TM-CONV-004) lacked the required THREAT code comments

## How
- Removed the stale merge conflict marker (line 221)
- Updated TM-NET-001 table row and mitigation details to reflect actual code behavior
- Added THREAT code comments at mitigation points for TM-DOS-002, TM-NET-003, TM-CONV-001, TM-CONV-004

## Risk
- Low — comment-only and documentation changes, no logic modified

Closes #34, Closes #35, Closes #36

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict