### PR TITLE
fix(security): block IPv4-compatible and 6to4 IPv6 addresses in SSRF protection

### DIFF
--- a/crates/fetchkit/src/dns.rs
+++ b/crates/fetchkit/src/dns.rs
@@ -253,6 +253,42 @@ fn is_blocked_ipv6(ip: Ipv6Addr) -> bool {
         return true;
     }
 
+    // THREAT[TM-SSRF-006]: IPv4-compatible IPv6 (deprecated, ::<ipv4>, prefix 0000:0000:...)
+    // Extract embedded IPv4 from the low 32 bits and validate it
+    if segments[0] == 0
+        && segments[1] == 0
+        && segments[2] == 0
+        && segments[3] == 0
+        && segments[4] == 0
+        && segments[5] == 0
+        && !(segments[6] == 0 && segments[7] == 0)
+    // exclude :: (unspecified) and ::1 (loopback)
+    {
+        let ipv4 = Ipv4Addr::new(
+            (segments[6] >> 8) as u8,
+            segments[6] as u8,
+            (segments[7] >> 8) as u8,
+            segments[7] as u8,
+        );
+        if is_blocked_ipv4(ipv4) {
+            return true;
+        }
+    }
+
+    // THREAT[TM-SSRF-006]: 6to4 addresses (2002::/16) embed IPv4 in bits 16-47
+    // e.g. 2002:7f00:0001:: encodes 127.0.0.1
+    if segments[0] == 0x2002 {
+        let ipv4 = Ipv4Addr::new(
+            (segments[1] >> 8) as u8,
+            segments[1] as u8,
+            (segments[2] >> 8) as u8,
+            segments[2] as u8,
+        );
+        if is_blocked_ipv4(ipv4) {
+            return true;
+        }
+    }
+
     false
 }
 
@@ -400,6 +436,38 @@ mod tests {
         assert!(p.is_blocked_ip("::ffff:169.254.169.254".parse().unwrap()));
         // ::ffff:8.8.8.8 should NOT be blocked (maps to public)
         assert!(!p.is_blocked_ip("::ffff:8.8.8.8".parse().unwrap()));
+    }
+
+    // THREAT[TM-SSRF-011]: IPv4-compatible IPv6 addresses (deprecated)
+    #[test]
+    fn test_ipv4_compatible_ipv6_blocked() {
+        let p = policy();
+        // ::7f00:1 is the hex form of ::127.0.0.1 (IPv4-compatible, deprecated)
+        assert!(p.is_blocked_ip("::7f00:1".parse().unwrap()));
+        // ::a00:1 is ::10.0.0.1 (private)
+        assert!(p.is_blocked_ip("::a00:1".parse().unwrap()));
+        // ::c0a8:1 is ::192.168.0.1 (private)
+        assert!(p.is_blocked_ip("::c0a8:1".parse().unwrap()));
+        // ::a9fe:a9fe is ::169.254.169.254 (metadata)
+        assert!(p.is_blocked_ip("::a9fe:a9fe".parse().unwrap()));
+        // ::808:808 is ::8.8.8.8 (public) — should NOT be blocked
+        assert!(!p.is_blocked_ip("::808:808".parse().unwrap()));
+    }
+
+    // THREAT[TM-SSRF-011]: 6to4 addresses (2002::/16)
+    #[test]
+    fn test_6to4_ipv6_blocked() {
+        let p = policy();
+        // 2002:7f00:1:: encodes 127.0.0.1
+        assert!(p.is_blocked_ip("2002:7f00:1::".parse().unwrap()));
+        // 2002:a00:1:: encodes 10.0.0.1
+        assert!(p.is_blocked_ip("2002:a00:1::".parse().unwrap()));
+        // 2002:c0a8:1:: encodes 192.168.0.1
+        assert!(p.is_blocked_ip("2002:c0a8:1::".parse().unwrap()));
+        // 2002:a9fe:a9fe:: encodes 169.254.169.254
+        assert!(p.is_blocked_ip("2002:a9fe:a9fe::".parse().unwrap()));
+        // 2002:808:808:: encodes 8.8.8.8 (public) — should NOT be blocked
+        assert!(!p.is_blocked_ip("2002:808:808::".parse().unwrap()));
     }
 
     // ==================== Public IPs allowed ====================

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -103,6 +103,7 @@ only allow connections to publicly-routable IP addresses by default.
 | TM-SSRF-004 | Numeric IP variants (octal 0177.0.0.1, hex 0x7f000001, decimal 2130706433) | High | URL parsed by `url` crate which normalizes IP representations; resolved IP validated | MITIGATED |
 | TM-SSRF-005 | DNS rebinding (hostname resolves to public IP, then re-resolves to private) | High | Pin DNS resolution via `reqwest::ClientBuilder::resolve()`; validated IP used for connection | MITIGATED |
 | TM-SSRF-006 | IPv6-mapped IPv4 (::ffff:127.0.0.1) | High | `to_canonical()` extracts IPv4 from mapped addresses before range check | MITIGATED |
+| TM-SSRF-011 | IPv4-compatible IPv6 (::127.0.0.1) and 6to4 (2002:7f00:1::) | Medium | Extract embedded IPv4 from deprecated IPv4-compatible and 6to4 addresses, validate against blocked ranges | MITIGATED |
 | TM-SSRF-007 | DNS names resolving to private IPs | Critical | Post-resolution IP check catches all DNS-to-private-IP scenarios | MITIGATED |
 | TM-SSRF-008 | Kubernetes service DNS (*.svc.cluster.local) | High | Resolves to cluster IPs which are private ranges; blocked by IP check | MITIGATED |
 | TM-SSRF-009 | URL with credentials (http://user:pass@internal) | Medium | Credentials in URL passed through to reqwest; no credential stripping | **ACCEPTED** |
@@ -136,6 +137,12 @@ caught after normalization.
 After validating the resolved IP, FetchKit uses `reqwest::ClientBuilder::resolve(host, addr)`
 to pin the connection to the validated IP. This prevents reqwest from re-resolving
 the hostname during connection establishment.
+
+**TM-SSRF-011 — IPv4-compatible and 6to4 IPv6 addresses (MITIGATED):**
+IPv4-compatible IPv6 addresses (`::<ipv4>`, deprecated RFC 4291) and 6to4
+addresses (`2002::/16`, RFC 3056) embed IPv4 addresses that `to_canonical()`
+does not extract. `is_blocked_ipv6()` now detects both formats, extracts
+the embedded IPv4, and validates it against the blocked ranges.
 
 **TM-SSRF-009 — URL credentials (ACCEPTED):**
 FetchKit passes URLs to reqwest as-is. If credentials are embedded in the URL,
@@ -358,6 +365,7 @@ None — all previously open threats have been mitigated.
 | Private IP blocking | TM-SSRF | `DnsPolicy::block_private_ips()` with resolve-then-check |
 | DNS pinning | TM-SSRF | `reqwest::ClientBuilder::resolve()` per redirect hop |
 | IPv6-mapped-IPv4 canonicalization | TM-SSRF | `IpAddr::to_canonical()` before range check |
+| IPv4-compatible/6to4 extraction | TM-SSRF | Extract embedded IPv4 from `::` and `2002::` prefixes, validate |
 | Manual redirect following | TM-SSRF | `Policy::none()` with IP validation at each hop |
 | First-byte timeout | TM-DOS | 1-second connect+response timeout |
 | Body timeout | TM-DOS | 30-second streaming body timeout |


### PR DESCRIPTION
## What
Block deprecated IPv4-compatible IPv6 and 6to4 addresses that embed private IPv4 in SSRF protection.

## Why
`is_blocked_ipv6()` only blocked standard IPv6 ranges (link-local, unique local, etc.) and relied on `to_canonical()` for IPv6-mapped IPv4 (`::ffff:`). But IPv4-compatible (`::<ipv4>`) and 6to4 (`2002::/16`) addresses also embed IPv4 and were not checked, creating a defense-in-depth gap.

## How
- Extract embedded IPv4 from IPv4-compatible addresses (low 32 bits) and 6to4 addresses (bits 16-47)
- Validate extracted IPv4 against existing blocked ranges
- Add TM-SSRF-011 to threat model with mitigation details
- Add unit tests for both address types with private and public IPv4 embeddings

## Risk
- Low — adds blocking for rare address types; public IPv4 embeddings are correctly allowed

Closes #39

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict