### PR TITLE
docs: clarify latest-main requirement for worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This repo is intended to be runnable locally and easy for coding agents to work in.
 
+Always make sure you are working on top of latest main from remote. Especially in detached worktrees, fetch `origin/main` and rebase or branch from it before editing.
+
 Style
 Telegraph. Drop filler/grammar. Min tokens (global AGENTS + replies).
 
@@ -178,7 +180,7 @@ doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
 
 Before creating a pull request, ensure:
 
-1. **Branch rebased**: Rebase on latest main to avoid merge conflicts
+1. **Branch rebased**: Rebase on latest main to avoid merge conflicts. In detached worktrees, first create or switch to a topic branch that is based on `origin/main`.
    ```bash
    git fetch origin main && git rebase origin/main
    ```


### PR DESCRIPTION
## What
Add explicit AGENTS guidance to stay on the latest remote main, with detached worktree handling called out near the top of the file and in the pre-PR checklist.

## Why
Detached worktrees make it easy to start from a stale commit. The repo guidance should state this requirement plainly where agents will see it before editing or shipping.

## How
Updated `AGENTS.md` with a top-level reminder to fetch `origin/main` and rebase or branch from it before editing in detached worktrees, and expanded the rebased-branch checklist item to mention the worktree case.

## Risk
- Low
- Documentation-only change to repo workflow guidance

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict