### PR TITLE
feat: add process-issues skill for e2e GitHub issue resolution

### DIFF
--- a/.claude/commands/processing-issues.md
+++ b/.claude/commands/processing-issues.md
@@ -1,18 +1,17 @@
 # Processing Issues
 
-Batch-process GitHub issues or open threat-model items. Triage, implement, and
-ship via individual PRs.
+Resolve all qualifying open GitHub issues end-to-end. Each issue becomes exactly one shipped PR.
+
+Delegates to the `process-issues` skill (`.claude/skills/process-issues/SKILL.md`).
 
 ## Arguments
 
-- `$ARGUMENTS` - Optional: filter, label, or issue numbers (e.g. "bug", "#12 #15")
+- `$ARGUMENTS` - Optional: specific issue numbers (e.g. "42 55") or labels. If omitted, process all open issues.
 
-## Requirements
+## Instructions
 
-- **One issue = one PR.** Never bundle unrelated issues into a single PR.
-- **Ship each PR via `/ship`.** Every PR follows the full shipping process.
-- **Max 5 issues in parallel.** Work in batches if more than 5.
-- **Rebase often.** Rebase in-progress branches on `main` periodically,
-  especially after something is merged, to avoid conflict pileup.
-- **Reference the issue** in the PR body (e.g. "Closes #42").
-- **Report results.** After processing, summarize each issue with PR link and status.
+Run the `process-issues` skill with the provided arguments. The skill handles:
+
+1. Listing and filtering qualifying issues
+2. Per-issue: scope, test, implement, `/ship`
+3. Post-processing: scan for `#[ignore]` tests that may now pass

--- a/.claude/skills/process-issues/SKILL.md
+++ b/.claude/skills/process-issues/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: process-issues
+description: Resolve all open GitHub issues. Each issue becomes exactly one shipped PR. Trigger when user says "process issues", "work through issues", "resolve issues", "handle open issues", "fix all issues", or asks to resolve GitHub issues end-to-end.
+user_invocable: true
+---
+
+Resolve all qualifying open GitHub issues. Each issue becomes exactly one merged PR. Do not stop until every issue is resolved or explicitly deferred.
+
+## Arguments
+
+- `$ARGUMENTS` - Optional: specific issue numbers (e.g. "42 55") or labels. If omitted, process all open issues.
+
+## Goal
+
+Every qualifying open issue has a merged PR that resolves it. **One issue = one PR. No bundling. No skipping.**
+
+## Qualifying issues
+
+Only process issues that meet ONE of:
+- Created by `chaliy`
+- Has a comment from `chaliy` approving it
+
+Skip all others silently.
+
+## Per-issue outcomes
+
+For each qualifying issue (ordered by issue number), achieve ALL of these before moving to the next:
+
+### 1. Issue is understood and scoped
+
+- Classify: bug, feat, test, chore, refactor, docs
+- Identify affected areas: core library, CLI, MCP server, fetchers, HTML conversion, URL filtering, Python bindings
+- Branch created from latest main: `fix/issue-{N}-{short-slug}`
+
+### 2. Failing test exists (bugs) or scaffold test exists (features)
+
+- A test that demonstrates the bug or validates the feature exists in the relevant crate's test module or integration tests
+- For bugs: test fails before the fix, passes after
+- Use `wiremock` for HTTP mocking (no real external network calls)
+
+### 3. Fix or feature is implemented
+
+- Minimal, focused changes
+- Positive and negative tests pass
+- Security tests added if change touches URL parsing, fetchers, HTML conversion, network, or user input (per `specs/threat-model.md`)
+- Threat model updated if new attack surface (per `specs/threat-model.md`)
+
+### 4. Ship via `/ship`
+
+Invoke the `/ship` skill to handle all remaining steps: spec updates, artifact updates, code simplification, security review, smoke testing, quality gates, PR creation, CI, and merge.
+
+Pass context: `Closes #N — <short description of the fix/feature>`
+
+Do NOT duplicate any `/ship` steps manually — let the skill handle the full pipeline.
+
+After `/ship` completes and the PR is merged, return to main before next issue: `git checkout main && git pull origin main`
+
+## After all issues
+
+Scan for `#[ignore]` tests that may now pass. Un-ignore any that are green. Single PR for all un-ignored tests.
+
+## Rules
+
+- **One issue = one PR.** Non-negotiable. Never bundle multiple issues.
+- If an issue is unclear or not reproducible, comment asking for clarification and skip to next.
+- If a fix would be >500 lines, split into sub-issues and link them.
+- Never skip the failing-test-first step for bugs.
+- Always rebase on latest main between issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ When asked to "fix and ship": implement fix first, then run `/ship`.
 Available skills:
 - `/ship` — 10-phase shipping workflow (`.claude/commands/ship.md`)
 - `/processing-issues` — Batch-process GitHub issues: triage, implement, ship via individual PRs (`.claude/commands/processing-issues.md`)
+- `/process-issues` — Resolve all open GitHub issues e2e; one issue = one shipped PR (`.claude/skills/process-issues/SKILL.md`)
 
 ### Agent-portable paths
 


### PR DESCRIPTION
## What
Add the `process-issues` skill (`.claude/skills/process-issues/SKILL.md`) for end-to-end GitHub issue resolution, adopted from bashkit and adapted for fetchkit's Rust/cargo domain.

## Why
The repo needed a structured skill for batch-processing GitHub issues — scope, test-first, implement, ship — with one issue per PR. This mirrors the proven pattern from bashkit.

## How
- Created `.claude/skills/process-issues/SKILL.md` with full e2e workflow: qualify issues, classify, branch, test-first, implement, delegate to `/ship`
- Adapted affected areas for fetchkit: core library, CLI, MCP server, fetchers, HTML conversion, URL filtering, Python bindings
- Specified `wiremock` for HTTP mocking (no real network calls)
- Simplified `.claude/commands/processing-issues.md` to delegate to the skill
- Updated `AGENTS.md` skills listing

## Risk
- Low
- Documentation-only change, no code affected

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict