### PR TITLE
fix(python): preserve hardened redirect policy

### DIFF
--- a/crates/fetchkit-python/src/lib.rs
+++ b/crates/fetchkit-python/src/lib.rs
@@ -189,7 +189,7 @@ impl PyFetchKitTool {
         respect_proxy_env=false,
         allowed_ports=None,
         blocked_hosts=None,
-        same_host_redirects_only=false,
+        same_host_redirects_only=None,
         hardened=false
     ))]
     fn new(
@@ -203,7 +203,7 @@ impl PyFetchKitTool {
         respect_proxy_env: bool,
         allowed_ports: Option<Vec<u16>>,
         blocked_hosts: Option<Vec<String>>,
-        same_host_redirects_only: bool,
+        same_host_redirects_only: Option<bool>,
         hardened: bool,
     ) -> PyResult<Self> {
         let mut builder = ToolBuilder::new()
@@ -217,7 +217,7 @@ impl PyFetchKitTool {
 
         builder = builder
             .block_private_ips(block_private_ips)
-            .same_host_redirects_only(same_host_redirects_only);
+            .same_host_redirects_only_if_set(same_host_redirects_only);
 
         if let Some(ua) = user_agent {
             builder = builder.user_agent(ua);
@@ -324,7 +324,7 @@ fn fetch(
     as_text: Option<bool>,
 ) -> PyResult<PyFetchResponse> {
     let tool = PyFetchKitTool::new(
-        true, true, None, None, None, None, true, false, None, None, false, false,
+        true, true, None, None, None, None, true, false, None, None, None, false,
     )?;
     tool.fetch(url, method, as_markdown, as_text)
 }

--- a/crates/fetchkit/src/tool.rs
+++ b/crates/fetchkit/src/tool.rs
@@ -245,6 +245,14 @@ impl ToolBuilder {
         self
     }
 
+    /// Restrict redirects to the original host only when the caller set a value.
+    pub fn same_host_redirects_only_if_set(mut self, enable: Option<bool>) -> Self {
+        if let Some(enable) = enable {
+            self.same_host_redirects_only = enable;
+        }
+        self
+    }
+
     /// Control private/reserved IP range blocking (SSRF prevention)
     ///
     /// Enabled by default. When enabled, FetchKit resolves hostnames to IP
@@ -1110,6 +1118,26 @@ mod tests {
         assert!(tool.blocked_hosts.contains(&"localhost".to_string()));
         assert!(tool.blocked_hosts.contains(&".cluster.local".to_string()));
         assert!(tool.same_host_redirects_only);
+    }
+
+    #[test]
+    fn test_tool_builder_preserves_hardened_redirect_policy_when_override_is_unset() {
+        let tool = Tool::builder()
+            .hardened()
+            .same_host_redirects_only_if_set(None)
+            .build();
+
+        assert!(tool.same_host_redirects_only);
+    }
+
+    #[test]
+    fn test_tool_builder_allows_explicit_redirect_policy_override() {
+        let tool = Tool::builder()
+            .hardened()
+            .same_host_redirects_only_if_set(Some(false))
+            .build();
+
+        assert!(!tool.same_host_redirects_only);
     }
 
     #[test]


### PR DESCRIPTION
## What
Preserve the hardened same-host redirect policy in the Python binding unless the caller explicitly overrides it.

Closes #96.

## Why
`FetchKitTool(hardened=True)` in Python immediately overwrote the hardened redirect setting with the constructor's default `same_host_redirects_only=False`, which made the Python hardened profile weaker than the Rust and CLI profiles.

## How
- make the Python constructor treat `same_host_redirects_only` as optional instead of defaulting it to `False`
- add a shared `ToolBuilder::same_host_redirects_only_if_set` helper so omission preserves hardened defaults while explicit `False` still overrides them
- cover the preserve-vs-override semantics with Rust `ToolBuilder` tests and validate the binding compiles with `cargo check -p fetchkit-python`

## Risk
- Low
- Python callers who relied on the old implicit weakening now get the documented hardened behavior unless they pass `same_host_redirects_only=False` explicitly

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [ ] Documentation is updated
- [x] Specs are up to date and not in conflict
- [x] Python binding compiles locally (`cargo check -p fetchkit-python`)
- [ ] Python binding runtime test executed locally (blocked by local Python test binary link environment)