### PR TITLE
fix(fetchers): surface malformed body errors

### DIFF
--- a/crates/fetchkit/src/fetchers/default.rs
+++ b/crates/fetchkit/src/fetchers/default.rs
@@ -292,7 +292,8 @@ impl Fetcher for DefaultFetcher {
 
         // THREAT[TM-DOS-001]: Read body with timeout and size limit
         // THREAT[TM-DOS-003]: Size limit also protects against compressed content bombs
-        let (body, truncated) = read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await;
+        let (body, truncated) =
+            read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
         let size = body.len() as u64;
 
         // Convert to string
@@ -438,7 +439,8 @@ impl Fetcher for DefaultFetcher {
         }
 
         // Read raw body (no binary rejection for file saves)
-        let (body, truncated) = read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await;
+        let (body, truncated) =
+            read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
         let size = body.len() as u64;
 
         // Save through the FileSaver
@@ -644,7 +646,7 @@ pub(crate) async fn read_body_with_timeout(
     response: reqwest::Response,
     timeout: Duration,
     max_size: usize,
-) -> (Bytes, bool) {
+) -> Result<(Bytes, bool), FetchError> {
     let mut body = Vec::new();
     let mut stream = response.bytes_stream();
     let deadline = tokio::time::Instant::now() + timeout;
@@ -660,29 +662,31 @@ pub(crate) async fn read_body_with_timeout(
                         let remaining = max_size.saturating_sub(body.len());
                         if remaining == 0 {
                             warn!("Body size limit reached ({}), truncating", max_size);
-                            return (Bytes::from(body), true);
+                            return Ok((Bytes::from(body), true));
                         }
                         if bytes.len() > remaining {
                             body.extend_from_slice(&bytes[..remaining]);
                             warn!("Body size limit reached ({}), truncating", max_size);
-                            return (Bytes::from(body), true);
+                            return Ok((Bytes::from(body), true));
                         }
                         body.extend_from_slice(&bytes);
                     }
                     Some(Err(e)) => {
                         error!("Error reading body chunk: {}", e);
-                        let has_content = !body.is_empty();
-                        return (Bytes::from(body), has_content);
+                        if body.is_empty() {
+                            return Err(FetchError::from_reqwest(e));
+                        }
+                        return Ok((Bytes::from(body), true));
                     }
                     None => {
                         // Stream complete
-                        return (Bytes::from(body), false);
+                        return Ok((Bytes::from(body), false));
                     }
                 }
             }
             _ = timeout_future => {
                 warn!("Body timeout reached, returning partial content");
-                return (Bytes::from(body), true);
+                return Ok((Bytes::from(body), true));
             }
         }
     }

--- a/crates/fetchkit/src/fetchers/docs_site.rs
+++ b/crates/fetchkit/src/fetchers/docs_site.rs
@@ -239,7 +239,7 @@ async fn fetch_llms_txt_direct(
     }
 
     let max_body_size = options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE);
-    let (body, truncated) = read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await;
+    let (body, truncated) = read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
     let size = body.len() as u64;
     let mut content = String::from_utf8_lossy(&body).to_string();
 

--- a/crates/fetchkit/tests/integration.rs
+++ b/crates/fetchkit/tests/integration.rs
@@ -5,6 +5,8 @@ use fetchkit::{
     HttpMethod, LocalFileSaver, Tool,
 };
 use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 use tower::Service;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -32,6 +34,25 @@ fn test_tool_with_save() -> Tool {
         .build()
 }
 
+async fn spawn_malformed_chunked_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = [0_u8; 1024];
+            let _ = stream.read(&mut buf).await;
+            let _ = stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\nZZ\r\nboom\r\n0\r\n\r\n",
+                )
+                .await;
+        }
+    });
+
+    format!("http://{addr}/")
+}
+
 #[tokio::test]
 async fn test_simple_get() {
     let mock_server = MockServer::start().await;
@@ -53,6 +74,28 @@ async fn test_simple_get() {
     assert_eq!(resp.content_type, Some("text/plain".to_string()));
     assert!(resp.content.unwrap().contains("Hello, World!"));
     assert_eq!(resp.format, Some("raw".to_string()));
+}
+
+#[tokio::test]
+async fn test_malformed_chunked_body_returns_error() {
+    let req = FetchRequest::new(spawn_malformed_chunked_server().await);
+    let result = fetch_with_options(req, test_options()).await;
+
+    assert!(matches!(result, Err(FetchError::RequestError(_))));
+}
+
+#[tokio::test]
+async fn test_save_to_file_malformed_chunked_body_does_not_create_empty_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let saver = LocalFileSaver::new(Some(dir.path().to_path_buf()));
+    let req =
+        FetchRequest::new(spawn_malformed_chunked_server().await).save_to_file("malformed.txt");
+    let result = test_tool_with_save()
+        .execute_with_saver(req, Some(&saver))
+        .await;
+
+    assert!(matches!(result, Err(FetchError::RequestError(_))));
+    assert!(!dir.path().join("malformed.txt").exists());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What
Treat malformed zero-byte response bodies as fetch errors instead of successful empty responses.

Closes #98.

## Why
`read_body_with_timeout()` collapsed a body-stream failure before the first chunk into `(empty, false)`. That let malformed chunked responses look like successful `200 OK` fetches with empty content, and the same path could also create misleading zero-byte files under `save_to_file`.

## How
- change `read_body_with_timeout()` to return `FetchError` when the body stream fails before any bytes are read
- preserve partial-body behavior for mid-stream failures by returning the partial bytes as `truncated=true`
- propagate the new result through the default fetcher and direct `llms.txt` docs-site path
- add regressions for malformed chunked responses in both normal fetch and `save_to_file` flows

## Risk
- Low
- Changes only the malformed-body error path; successful responses, timeouts, size caps, and partial-body truncation stay on the existing behavior

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [ ] Documentation is updated
- [x] Specs are up to date and not in conflict
- [x] `cargo fmt --all` is passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` is passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` is passed
- [x] `cargo build --workspace --exclude fetchkit-python --release` is passed
