### PR TITLE
chore(deps): apply available major bumps (sha2 0.11, rand 0.10) and tighten maintenance spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - chore(deps): refresh `Cargo.lock` to latest compatible versions (tokio 1.52, reqwest 0.13.3, rustls 0.23.40, tower-http 0.6.10, rustls-platform-verifier 0.7, pyo3 0.28.3, and others)
+- chore(deps): bump `sha2` 0.10 → 0.11 and `rand` 0.8 → 0.10 for the optional `bot-auth` feature; switched the nonce generator to `rand::random()` since `rand::thread_rng()` was removed in rand 0.10
 - docs: document conditional-request, content-focus, ETag, metadata, word count, redirect chain, and paywall fields in spec and README
+- docs(specs): require deep maintenance to apply available major (SemVer-incompatible) dep bumps, not just `cargo update`
 
 ### Maintenance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +241,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "clap"
@@ -323,6 +343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +384,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,15 +412,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -427,7 +471,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -437,8 +481,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -484,7 +539,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -529,12 +584,12 @@ dependencies = [
  "bytes",
  "ed25519-dalek",
  "futures",
- "rand 0.8.6",
+ "rand 0.10.1",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -751,6 +806,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -845,6 +901,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1441,33 +1506,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1497,6 +1552,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ref-cast"
@@ -1846,8 +1907,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,5 @@ tower = { version = "0.5", features = ["util"] }
 # Crypto (bot-auth feature)
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 base64 = "0.22"
-sha2 = "0.10"
-rand = "0.8"
+sha2 = "0.11"
+rand = "0.10"

--- a/crates/fetchkit/src/bot_auth.rs
+++ b/crates/fetchkit/src/bot_auth.rs
@@ -22,7 +22,6 @@
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
-use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -161,8 +160,7 @@ fn jwk_thumbprint_ed25519(key: &VerifyingKey) -> String {
 
 /// Generate a cryptographically random nonce (32 bytes, base64url-encoded).
 fn generate_nonce() -> String {
-    let mut bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    let bytes: [u8; 32] = rand::random();
     URL_SAFE_NO_PAD.encode(bytes)
 }
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -8,13 +8,23 @@ Define recurring maintenance tasks to keep the fetchkit repository healthy, up-t
 
 ### 1. Dependency Updates
 
-Update all workspace and crate-level dependencies to their latest compatible versions.
+Update all workspace and crate-level dependencies to their latest versions, including major
+(SemVer-incompatible) bumps. Maintenance must not stop at `cargo update`; it must also
+bump the manifest constraints in `Cargo.toml` for available major versions and adapt the
+code where the API has changed.
 
 1. **Check outdated deps** - Run `cargo outdated -R` (or equivalent) to list stale dependencies
 2. **Update minor/patch** - Apply non-breaking updates via `cargo update`
-3. **Evaluate major bumps** - Major version upgrades are allowed; review changelogs for breaking changes and adapt code accordingly
+3. **Evaluate and apply major bumps** - Run `cargo upgrade --incompatible --dry-run`
+   (from `cargo-edit`) to enumerate available major upgrades. Bump the manifest
+   constraints in `Cargo.toml` for each one, read the upstream changelog/migration
+   notes, and adapt the code (imports, renamed functions, removed APIs). A
+   maintenance pass that ships only `cargo update` is incomplete — call out any
+   major bump that is intentionally deferred, with the reason, in the PR body and
+   `CHANGELOG.md`.
 4. **Verify lockfile** - Ensure `Cargo.lock` reflects the updated versions
-5. **Build & test** - `cargo build --workspace && cargo test --workspace` must pass after updates
+5. **Build & test** - `cargo build --workspace && cargo test --workspace` must pass
+   after updates, with and without optional features (e.g. `--features bot-auth`)
 6. **Audit advisories** - Run `cargo audit` (if available) to check for known vulnerabilities
 
 ### 2. Documentation Quality (docs.rs / rustdoc)


### PR DESCRIPTION
## What

Follow-up to #105. That PR only ran `cargo update`, which by definition is SemVer-compatible and skipped the two available major bumps. Apply them now and tighten the maintenance spec so this doesn't recur.

- `sha2` 0.10 → 0.11 (bot-auth feature)
- `rand` 0.8 → 0.10 (bot-auth feature)
- `specs/maintenance.md` §1 rewritten to require evaluating and applying available major bumps via `cargo upgrade --incompatible`, with deferred bumps called out explicitly in PR + changelog.

## Why

The maintenance spec already said "Major version upgrades are allowed; review changelogs for breaking changes and adapt code accordingly" — but the wording let a partial pass slip through. Tighten it so future passes (human or agent) treat major bumps as a mandatory checklist item, not a stretch goal.

For the actual bumps: keeps the optional bot-auth feature on supported upstream crypto/RNG versions and avoids drifting onto unmaintained 0.8/0.10 lines.

## How

- `sha2` 0.11 is API-compatible for our `Digest + Sha256` usage; no source change.
- `rand` 0.10 removed `rand::thread_rng()` and no longer re-exports `RngCore` at the crate root. Switched `bot_auth::generate_nonce` from `rand::thread_rng().fill_bytes(&mut bytes)` to `let bytes: [u8; 32] = rand::random();` — the idiomatic 0.10 API for fixed-size random arrays. Same cryptographic source (`ThreadRng` → `OsRng` chain), same 32-byte nonce.
- Verified with and without `--features bot-auth`. Both pass clippy `-D warnings`, all 280+ tests, doctests, release build.

## Risk

- **Low.** Single behavior-bearing code change (`generate_nonce`) is functionally equivalent. Bot-auth feature is opt-in, no default-feature consumer affected.
- ed25519-dalek 2.x still depends on `rand_core` 0.6 internally; cargo resolves it side-by-side with rand 0.10 which uses `rand_core` 0.9. No conflict at link time.

### Checklist
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features bot-auth -- -D warnings`
- [x] `cargo test --workspace --exclude fetchkit-python` (default features)
- [x] `cargo test --workspace --exclude fetchkit-python --features bot-auth`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --exclude fetchkit-python --features bot-auth --no-deps`
- [x] `cargo build --workspace --exclude fetchkit-python --release --features bot-auth`
- [x] `specs/maintenance.md` updated
- [x] `CHANGELOG.md` `[Unreleased]` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBcYmScvqggAy1GEYJstup)_