### PR TITLE
fix(fetchers): enforce RSS body size and timeout limits

### DIFF
--- a/crates/fetchkit/src/fetchers/rss_feed.rs
+++ b/crates/fetchkit/src/fetchers/rss_feed.rs
@@ -5,7 +5,10 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
-use crate::fetchers::default::{apply_bot_auth_if_enabled, send_request_following_redirects};
+use crate::fetchers::default::{
+    apply_bot_auth_if_enabled, read_body_with_timeout, send_request_following_redirects,
+    BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE,
+};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
@@ -129,10 +132,10 @@ impl Fetcher for RSSFeedFetcher {
             .unwrap_or("")
             .to_string();
 
-        let body = response
-            .text()
-            .await
-            .map_err(|e| FetchError::RequestError(e.to_string()))?;
+        let max_body_size = options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE);
+        let (body, _truncated) =
+            read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
+        let body = String::from_utf8_lossy(&body).into_owned();
 
         // Detect feed type: by XML structure first, then content-type
         let is_feed_by_ct = Self::is_feed_content_type(&content_type);


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory/time use when fetching feeds by applying the same bounded read helpers used by the default fetcher to RSS/Atom responses.

### Description
- Import and use `read_body_with_timeout`, `BODY_TIMEOUT`, and `DEFAULT_MAX_BODY_SIZE` from the default fetcher helpers.
- Replace `response.text()` with `read_body_with_timeout(response, BODY_TIMEOUT, max_body_size)` and convert the returned bytes with `String::from_utf8_lossy` so feed parsing respects `FetchOptions.max_body_size` or the default limit.
- Keep existing redirect/DNS handling via `send_request_following_redirects` unchanged to minimize behavioral changes.

### Testing
- Ran formatter with `cargo fmt --all` which completed successfully.
- Ran targeted unit tests with `cargo test -p fetchkit rss_feed -- --nocapture` and all RSS-related tests passed (`9 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ea591600832bae09be594c42f511)