### PR TITLE
fix(ci): pin publish workflow actions in secret-bearing jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     name: Publish fetchkit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Rust stable
         run: |
           rustup toolchain install stable --profile minimal
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-fetchkit
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Rust stable
         run: |
           rustup toolchain install stable --profile minimal

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,11 @@ jobs:
     name: Publish fetchkit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Verify version matches tag
         run: |
@@ -44,8 +47,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-fetchkit
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Wait for crates.io index update
         run: sleep 30


### PR DESCRIPTION
### Motivation
- Close a supply-chain vulnerability where mutable GitHub Action refs ran in publish jobs that later receive `CARGO_REGISTRY_TOKEN`, allowing a compromised action to tamper with the runner and exfiltrate the token. 
- Harden the publish workflow without changing the existing publish flow or behavior.

### Description
- Pinned `actions/checkout` to a full commit SHA in both `publish-fetchkit` and `publish-fetchkit-cli` jobs to remove mutable tag/branch risk. 
- Replaced `dtolnay/rust-toolchain@stable` with explicit `rustup` install and `rustup default stable` steps to avoid executing an unpinned third-party action before secrets are available. 
- Kept the existing `cargo publish` steps and job ordering intact so publish behavior is unchanged.

### Testing
- Verified the updated `.github/workflows/publish.yml` contents and line-by-line output with `sed`/`nl` to confirm the intended changes were applied. 
- Committed the change locally with `git commit` to ensure the repository accepts the modified workflow file. 
- Could not run CI or workspace Rust tests in this environment due to missing remote access, so recommend running `cargo test --workspace` and letting CI validate the workflow and secrets handling before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ed05f604832b8154b8b37d70a067)