### PR TITLE
fix(fetchers): bound HN timestamp formatting

### DIFF
--- a/crates/fetchkit/src/fetchers/hackernews.rs
+++ b/crates/fetchkit/src/fetchers/hackernews.rs
@@ -19,6 +19,9 @@ const API_TIMEOUT: Duration = Duration::from_secs(10);
 /// Max top-level comments to fetch
 const MAX_COMMENTS: usize = 20;
 
+/// Upper bound for accepted Unix timestamps (3000-01-01T00:00:00Z)
+const MAX_UNIX_TIMESTAMP: u64 = 32_503_680_000;
+
 /// Hacker News fetcher
 ///
 /// Matches `news.ycombinator.com/item?id={id}`, returning structured
@@ -191,8 +194,8 @@ fn format_hn_response(item: &HNItem, comments: &[(HNItem, Vec<HNItem>)]) -> Stri
     if let Some(score) = item.score {
         out.push_str(&format!("- **Score:** {}\n", score));
     }
-    if let Some(time) = item.time {
-        out.push_str(&format!("- **Time:** {}\n", format_unix_timestamp(time)));
+    if let Some(time) = item.time.and_then(format_unix_timestamp_bounded) {
+        out.push_str(&format!("- **Time:** {}\n", time));
     }
     if let Some(descendants) = item.descendants {
         out.push_str(&format!("- **Comments:** {}\n", descendants));
@@ -230,6 +233,15 @@ fn format_hn_response(item: &HNItem, comments: &[(HNItem, Vec<HNItem>)]) -> Stri
     }
 
     out
+}
+
+/// Format a Unix timestamp as an ISO 8601 UTC date-time string
+fn format_unix_timestamp_bounded(ts: u64) -> Option<String> {
+    if ts > MAX_UNIX_TIMESTAMP {
+        return None;
+    }
+
+    Some(format_unix_timestamp(ts))
 }
 
 /// Format a Unix timestamp as an ISO 8601 UTC date-time string
@@ -465,5 +477,14 @@ mod tests {
     fn test_format_unix_timestamp() {
         assert_eq!(format_unix_timestamp(0), "1970-01-01T00:00:00Z");
         assert_eq!(format_unix_timestamp(1704067200), "2024-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn test_format_unix_timestamp_bounded() {
+        assert_eq!(
+            format_unix_timestamp_bounded(1704067200),
+            Some("2024-01-01T00:00:00Z".to_string())
+        );
+        assert_eq!(format_unix_timestamp_bounded(u64::MAX), None);
     }
 }


### PR DESCRIPTION
### Motivation

- The Hacker News fetcher deserializes `time: Option<u64>` and passed unchecked values into a year-subtraction formatter, which enables a CPU-bound denial-of-service for crafted large timestamps.  
- The change aims to prevent unbounded work by rejecting out-of-range timestamps before running the custom formatter.

### Description

- Added `MAX_UNIX_TIMESTAMP` (3000-01-01T00:00:00Z) as an upper bound for accepted Unix timestamps.  
- Introduced `format_unix_timestamp_bounded(ts) -> Option<String>` which returns `None` for timestamps above the bound and otherwise delegates to the existing `format_unix_timestamp`.  
- Updated `format_hn_response()` to render `Time` metadata only when the bounded formatter returns `Some(String)`.  
- Added `test_format_unix_timestamp_bounded` unit test to verify valid timestamps are formatted and extreme values (e.g., `u64::MAX`) are rejected.

### Testing

- Ran formatting: `cargo fmt --all` which completed successfully.  
- Ran targeted unit tests: `cargo test -p fetchkit hackernews -- --nocapture`, and the Hacker News tests passed (all relevant tests, including the new bounded-timestamp test, succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ea9562f8832ba990a537c1b49660)