### PR TITLE
fix(ci): bind publish workflow to release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to publish (e.g. v0.2.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }}
       - name: Install Rust stable
         run: |
           rustup toolchain install stable --profile minimal
@@ -24,18 +31,22 @@ jobs:
 
       - name: Verify version matches tag
         run: |
-          TAG_VERSION="${{ github.event.release.tag_name }}"
-          if [ -n "$TAG_VERSION" ]; then
-            TAG_VERSION="${TAG_VERSION#v}"
-            CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-            if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
-              echo "Error: Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
-              exit 1
-            fi
-            echo "Version verified: $TAG_VERSION"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG_VERSION="${{ inputs.release_tag }}"
           else
-            echo "Manual dispatch - skipping tag verification"
+            TAG_VERSION="${{ github.event.release.tag_name }}"
           fi
+          if [ -z "$TAG_VERSION" ]; then
+            echo "Error: release tag is required"
+            exit 1
+          fi
+          TAG_VERSION="${TAG_VERSION#v}"
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "Error: Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
+            exit 1
+          fi
+          echo "Version verified: $TAG_VERSION"
 
       - name: Publish fetchkit to crates.io
         run: cargo publish -p fetchkit
@@ -48,6 +59,8 @@ jobs:
     needs: publish-fetchkit
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }}
       - name: Install Rust stable
         run: |
           rustup toolchain install stable --profile minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,9 @@ jobs:
           prerelease: false
 
       - name: Trigger publish workflow
-        run: gh workflow run publish.yml
+        run: |
+          gh workflow run publish.yml \
+            --ref "${{ steps.version.outputs.tag }}" \
+            -f release_tag="${{ steps.version.outputs.tag }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation

- The release workflow previously dispatched `publish.yml` via `gh workflow run publish.yml` without pinning a ref or providing the release tag, which allowed the publish job to run on an unverified/default ref and risk publishing unintended code to crates.io. 
- The intent is to ensure the publish step is cryptographically and procedurally bound to the reviewed release tag and to fail closed if that tag is missing or mismatched.

### Description

- `release.yml`: dispatch `publish.yml` with an explicit ref and input by invoking `gh workflow run publish.yml --ref "${{ steps.version.outputs.tag }}" -f release_tag="${{ steps.version.outputs.tag }}"`.
- `publish.yml`: add `workflow_dispatch.inputs.release_tag` as a required input so manual dispatches must provide the release tag.
- `publish.yml`: ensure both publish jobs checkout the exact release ref by passing `with: ref: ...` to `actions/checkout@v6` depending on event type.
- `publish.yml`: always verify the release tag (from `github.event.release.tag_name` or `inputs.release_tag`) matches `Cargo.toml` and fail if missing or mismatched, removing the previous fail-open behavior for manual dispatch.

### Testing

- Ran `cargo test --workspace`; test run produced `277 passed; 2 failed` and the failing tests are `fetchers::default::tests::test_redirect_target_handles_relative_location` and `fetchers::default::tests::test_redirect_target_rejects_non_http_location`, which are unrelated to these workflow-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0f5b4c832b84012c56babb085d)