### PR TITLE
fix(convert): avoid unicode slicing panic in attribute parsing

### DIFF
--- a/crates/fetchkit/src/convert.rs
+++ b/crates/fetchkit/src/convert.rs
@@ -414,9 +414,7 @@ pub fn html_to_text(html: &str) -> String {
 /// Extract attribute value from tag
 fn extract_attribute(tag: &str, attr: &str) -> Option<String> {
     let pattern = format!("{}=", attr);
-    let tag_lower = tag.to_lowercase();
-
-    if let Some(start) = tag_lower.find(&pattern) {
+    if let Some(start) = find_ascii_case_insensitive(tag, &pattern) {
         let rest = &tag[start + pattern.len()..];
         let rest = rest.trim_start();
 
@@ -433,6 +431,25 @@ fn extract_attribute(tag: &str, attr: &str) -> Option<String> {
                 .find(|c: char| c.is_whitespace() || c == '>')
                 .unwrap_or(rest.len());
             return Some(rest[..end].to_string());
+        }
+    }
+    None
+}
+
+fn find_ascii_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    for i in 0..=h.len() - n.len() {
+        if h[i..i + n.len()]
+            .iter()
+            .zip(n.iter())
+            .all(|(a, b)| a.to_ascii_lowercase() == *b)
+        {
+            return Some(i);
         }
     }
     None
@@ -1531,6 +1548,13 @@ mod tests {
         assert!(result.contains("Article header"));
         assert!(result.contains("Body"));
         assert!(!result.contains("Site header"));
+    }
+
+    #[test]
+    fn test_strip_boilerplate_unicode_before_role_attr_does_not_panic() {
+        let html = r#"<div İİ role="main"><p>Body</p></div>"#;
+        let result = strip_boilerplate(html);
+        assert!(result.contains("Body"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent a panic/DoS when parsing attributes from untrusted HTML that contains Unicode characters which change byte offsets when case-folded.  
- The vulnerable path is exercised by `content_focus = "main"` which calls boilerplate stripping that inspects `role` attributes on arbitrary tags.

### Description

- Replace `to_lowercase().find()` offset reuse with a byte-stable ASCII case-insensitive search by adding `find_ascii_case_insensitive()` and using it from `extract_attribute`.  
- Preserve existing attribute extraction semantics (quoted/unquoted values) and avoid slicing at offsets derived from Unicode-transformed strings.  
- Add a regression test `test_strip_boilerplate_unicode_before_role_attr_does_not_panic` that ensures `strip_boilerplate()` does not panic for tags with non-ASCII characters before a `role` attribute.

### Testing

- Ran the targeted unit test with `cargo test -p fetchkit strip_boilerplate_unicode_before_role_attr_does_not_panic`, which passed.  
- The change is localized to `crates/fetchkit/src/convert.rs` and the added test verifies the panic path is fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec1b95d4832b838dd9bc2aae0d7e)