### PR TITLE
fix(convert): avoid unicode offset panic in attribute extraction

### DIFF
--- a/crates/fetchkit/src/convert.rs
+++ b/crates/fetchkit/src/convert.rs
@@ -414,13 +414,11 @@ pub fn html_to_text(html: &str) -> String {
 /// Extract attribute value from tag
 fn extract_attribute(tag: &str, attr: &str) -> Option<String> {
     let pattern = format!("{}=", attr);
-    let start = tag
-        .char_indices()
-        .find_map(|(idx, _)| {
-            tag.get(idx..idx + pattern.len())
-                .filter(|candidate| candidate.eq_ignore_ascii_case(&pattern))
-                .map(|_| idx)
-        });
+    let start = tag.char_indices().find_map(|(idx, _)| {
+        tag.get(idx..idx + pattern.len())
+            .filter(|candidate| candidate.eq_ignore_ascii_case(&pattern))
+            .map(|_| idx)
+    });
 
     if let Some(start) = start {
         let rest = &tag[start + pattern.len()..];

--- a/crates/fetchkit/src/convert.rs
+++ b/crates/fetchkit/src/convert.rs
@@ -414,9 +414,15 @@ pub fn html_to_text(html: &str) -> String {
 /// Extract attribute value from tag
 fn extract_attribute(tag: &str, attr: &str) -> Option<String> {
     let pattern = format!("{}=", attr);
-    let tag_lower = tag.to_lowercase();
+    let start = tag
+        .char_indices()
+        .find_map(|(idx, _)| {
+            tag.get(idx..idx + pattern.len())
+                .filter(|candidate| candidate.eq_ignore_ascii_case(&pattern))
+                .map(|_| idx)
+        });
 
-    if let Some(start) = tag_lower.find(&pattern) {
+    if let Some(start) = start {
         let rest = &tag[start + pattern.len()..];
         let rest = rest.trim_start();
 
@@ -1253,6 +1259,10 @@ mod tests {
         assert_eq!(
             extract_attribute("div class=test", "class"),
             Some("test".to_string())
+        );
+        assert_eq!(
+            extract_attribute("a title=\"İİ\" href=x", "href"),
+            Some("x".to_string())
         );
     }
 


### PR DESCRIPTION
### Motivation
- The previous `extract_attribute` searched a lowercased copy of the tag for `attr=` and then sliced the original tag using that byte offset, which can panic when Unicode case-folding changes byte length (e.g. `İ`).
- Metadata extraction was made automatic for HTML responses, making this panic reachable from attacker-controlled HTML and enabling a denial-of-service.

### Description
- Replace the lowercasing+byte-offset search with a char-boundary scan over the original `tag` using `char_indices()` and an ASCII case-insensitive slice comparison via `eq_ignore_ascii_case` to locate `attr=` safely.
- Preserve the existing attribute value parsing logic (double/single-quoted and unquoted values) and keep DoS limits/behavior unchanged.
- Add a regression test for the reported Unicode-triggering input (`extract_attribute("a title=\"İİ\" href=x", "href")`) to ensure correct extraction and no panic.
- Modified file: `crates/fetchkit/src/convert.rs`.

### Testing
- Ran the targeted test with `cargo test -p fetchkit test_extract_attribute`, and it passed (`test_extract_attribute ... ok`).
- The targeted crate test run finished successfully with the new regression asserting the Unicode case did not cause a panic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0f92c0832bad3afe0a1d2a50ad)