### PR TITLE
fix(fetchers): avoid utf-8 panic in hn html stripping

### DIFF
--- a/crates/fetchkit/src/fetchers/hackernews.rs
+++ b/crates/fetchkit/src/fetchers/hackernews.rs
@@ -308,12 +308,12 @@ fn strip_html_tags(html: &str) -> String {
     let mut result = String::with_capacity(html.len());
     let mut in_tag = false;
 
-    for c in html.chars() {
+    for (idx, c) in html.char_indices() {
         match c {
             '<' => {
                 in_tag = true;
                 // Check for <p> tags -> newlines
-                let rest: String = html[html.len() - (html.len() - result.len())..]
+                let rest: String = html[idx + c.len_utf8()..]
                     .chars()
                     .take(3)
                     .collect();
@@ -381,6 +381,7 @@ mod tests {
     fn test_strip_html_tags() {
         assert_eq!(strip_html_tags("Hello <b>world</b>"), "Hello world");
         assert_eq!(strip_html_tags("a &amp; b"), "a & b");
+        assert_eq!(strip_html_tags("ab<é>xy<"), "abxy");
     }
 
     #[test]

--- a/crates/fetchkit/src/fetchers/hackernews.rs
+++ b/crates/fetchkit/src/fetchers/hackernews.rs
@@ -325,10 +325,7 @@ fn strip_html_tags(html: &str) -> String {
             '<' => {
                 in_tag = true;
                 // Check for <p> tags -> newlines
-                let rest: String = html[idx + c.len_utf8()..]
-                    .chars()
-                    .take(3)
-                    .collect();
+                let rest: String = html[idx + c.len_utf8()..].chars().take(3).collect();
                 if rest.starts_with("p>") || rest.starts_with("br") {
                     result.push('\n');
                 }


### PR DESCRIPTION
### Motivation
- Prevent a panic when stripping HTML from untrusted Hacker News item/comment text by avoiding slicing at non-char UTF-8 boundaries.

### Description
- Iterate the input with `html.char_indices()` and compute the lookahead slice using `idx + c.len_utf8()` instead of `result.len()`, and add a regression assertion `strip_html_tags("ab<é>xy<") == "abxy"`.

### Testing
- Added a focused unit assertion in `test_strip_html_tags` and ran `cargo test -p fetchkit hackernews::tests::test_strip_html_tags`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0fafe4832b8e8d1bd0ab39d12d)