### PR TITLE
fix(fetchers): harden arxiv fetcher input and body limits

### DIFF
--- a/crates/fetchkit/src/fetchers/arxiv.rs
+++ b/crates/fetchkit/src/fetchers/arxiv.rs
@@ -5,6 +5,7 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
+use crate::fetchers::default::{read_body_with_timeout, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
@@ -45,16 +46,24 @@ impl ArXivFetcher {
                 let id = segments[1..].join("/");
                 // Strip .pdf suffix if present
                 let id = id.strip_suffix(".pdf").unwrap_or(&id);
-                if id.is_empty() {
-                    None
-                } else {
+                if Self::is_valid_paper_id(id) {
                     Some(id.to_string())
+                } else {
+                    None
                 }
             }
             _ => None,
         }
     }
 
+    fn is_valid_paper_id(id: &str) -> bool {
+        !id.is_empty()
+            && !id.starts_with('/')
+            && !id.ends_with('/')
+            && id
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '/'))
+    }
     /// Returns true if this is a /pdf/ URL
     fn is_pdf_url(url: &Url) -> bool {
         url.path_segments()
@@ -107,7 +116,7 @@ impl Fetcher for ArXivFetcher {
             .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
 
         // Fetch via arXiv API (returns Atom XML)
-        let api_url = format!("http://export.arxiv.org/api/query?id_list={}", paper_id);
+        let api_url = format!("https://export.arxiv.org/api/query?id_list={}", paper_id);
 
         let response = client
             .get(&api_url)
@@ -125,10 +134,10 @@ impl Fetcher for ArXivFetcher {
             });
         }
 
-        let xml = response
-            .text()
-            .await
-            .map_err(|e| FetchError::RequestError(e.to_string()))?;
+        let max_body_size = options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE);
+        let (xml_bytes, _truncated) =
+            read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
+        let xml = String::from_utf8_lossy(&xml_bytes).into_owned();
 
         let is_pdf = Self::is_pdf_url(&url);
         let content = parse_arxiv_response(&xml, &paper_id, is_pdf);
@@ -342,6 +351,12 @@ mod tests {
     #[test]
     fn test_rejects_non_arxiv() {
         let url = Url::parse("https://example.org/abs/2301.07041").unwrap();
+        assert_eq!(ArXivFetcher::parse_url(&url), None);
+    }
+
+    #[test]
+    fn test_rejects_injected_paper_id() {
+        let url = Url::parse("https://arxiv.org/abs/&search_query=all:electron").unwrap();
         assert_eq!(ArXivFetcher::parse_url(&url), None);
     }
 


### PR DESCRIPTION
### Motivation
- Close a query-injection and DoS vector where arbitrary `/abs/...` or `/pdf/...` path segments were interpolated into the arXiv API query and the full API response was read without size limits.
- Reduce on-path tampering risk by avoiding plaintext HTTP to the arXiv export API.

### Description
- Added strict paper-id validation (`is_valid_paper_id`) in `ArXivFetcher::parse_url` to reject IDs containing unsafe characters such as `&` and other non-arXiv-safe characters, preventing query-string injection.
- Switched the arXiv API endpoint to use `https://export.arxiv.org` instead of `http://export.arxiv.org` to protect against response tampering.
- Enforced `max_body_size` and timeouts by reusing the shared `read_body_with_timeout` helper and `DEFAULT_MAX_BODY_SIZE`/`BODY_TIMEOUT` from the default fetcher instead of calling `response.text()` unbounded.
- Added a unit test (`test_rejects_injected_paper_id`) to assert that injected IDs are rejected; the change is contained to `crates/fetchkit/src/fetchers/arxiv.rs`.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p fetchkit arxiv` and the arXiv test suite passed: 14 tests ran and all passed.
- Performed targeted smoke verification of the modified fetcher logic during the test run and observed no regressions in the arXiv-related unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec1034c4832bb017199514937db2)