### PR TITLE
fix(fetchers): enforce body size limits in wikipedia fetcher

### DIFF
--- a/crates/fetchkit/src/fetchers/wikipedia.rs
+++ b/crates/fetchkit/src/fetchers/wikipedia.rs
@@ -5,6 +5,9 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
+use crate::fetchers::default::{
+    read_body_with_timeout, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE, TRUNCATION_MESSAGE,
+};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
@@ -154,7 +157,10 @@ impl Fetcher for WikipediaFetcher {
             });
         }
 
-        let summary: WikiSummary = summary_resp.json().await.map_err(|e| {
+        let max_body_size = options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE);
+        let (summary_body, _) =
+            read_body_with_timeout(summary_resp, BODY_TIMEOUT, max_body_size).await?;
+        let summary: WikiSummary = serde_json::from_slice(&summary_body).map_err(|e| {
             FetchError::FetcherError(format!("Failed to parse Wikipedia data: {}", e))
         })?;
 
@@ -171,8 +177,14 @@ impl Fetcher for WikipediaFetcher {
             .await
         {
             Ok(resp) if resp.status().is_success() => {
-                let html = resp.text().await.ok();
-                html.map(|h| crate::convert::html_to_markdown(&h))
+                let (html_body, truncated) =
+                    read_body_with_timeout(resp, BODY_TIMEOUT, max_body_size).await?;
+                let html = String::from_utf8_lossy(&html_body);
+                let mut markdown = crate::convert::html_to_markdown(&html);
+                if truncated {
+                    markdown.push_str(TRUNCATION_MESSAGE);
+                }
+                Some(markdown)
             }
             _ => None,
         };


### PR DESCRIPTION
### Motivation
- The specialized `WikipediaFetcher` previously used unbounded `json()`/`text()` calls which buffered full decompressed responses and bypassed the global `max_body_size` protection, creating an availability/DoS risk for large or compressed Wikipedia pages.
- The intent is to preserve the cleaner Wikipedia-specific fetcher while restoring the same size/time protections used by the `DefaultFetcher` to protect shared agent services.

### Description
- Reused the shared bounded reader `read_body_with_timeout` and related constants (`BODY_TIMEOUT`, `DEFAULT_MAX_BODY_SIZE`, `TRUNCATION_MESSAGE`) from the `default` fetcher utilities.
- Enforced `FetchOptions.max_body_size` (falling back to `DEFAULT_MAX_BODY_SIZE`) when reading the MediaWiki summary JSON and the HTML endpoints.
- Replaced `summary_resp.json().await` with a bounded read plus `serde_json::from_slice`, and replaced `resp.text().await` with a bounded byte read followed by `html_to_markdown`, appending the standard truncation message when applicable.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran the targeted tests `cargo test -p fetchkit wikipedia -- --nocapture`, and all wikipedia fetcher unit tests passed (`13 passed, 0 failed`).
- Ran the workspace `fetchkit` test binary during the workflow and observed no regressions in the fetcher-related integration slices that were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0fd34c832b96c3d99a2bdba9dc)