### PR TITLE
fix(fetchers): enforce SSRF safeguards in StackOverflow API fetcher

### DIFF
--- a/crates/fetchkit/src/fetchers/stackoverflow.rs
+++ b/crates/fetchkit/src/fetchers/stackoverflow.rs
@@ -15,6 +15,8 @@ use std::time::Duration;
 use url::Url;
 
 const API_TIMEOUT: Duration = Duration::from_secs(10);
+const STACKEXCHANGE_API_HOST: &str = "api.stackexchange.com";
+const STACKEXCHANGE_API_PORT: u16 = 443;
 
 /// Max answers to include
 const MAX_ANSWERS: usize = 10;
@@ -127,11 +129,21 @@ impl Fetcher for StackOverflowFetcher {
         let mut client_builder = reqwest::Client::builder()
             .connect_timeout(API_TIMEOUT)
             .timeout(API_TIMEOUT)
-            .redirect(reqwest::redirect::Policy::limited(3));
+            // THREAT[TM-SSRF-010]: no redirect following for API calls
+            .redirect(reqwest::redirect::Policy::none());
 
         if !options.respect_proxy_env {
             // THREAT[TM-NET-004]: Ignore ambient proxy env by default
             client_builder = client_builder.no_proxy();
+        }
+
+        if options.dns_policy.block_private {
+            let validated_addr = options
+                .dns_policy
+                .resolve_and_validate(STACKEXCHANGE_API_HOST, STACKEXCHANGE_API_PORT)
+                .map_err(|_| FetchError::BlockedUrl)?;
+            // THREAT[TM-SSRF-005]: pin validated DNS answer for API host
+            client_builder = client_builder.resolve(STACKEXCHANGE_API_HOST, validated_addr);
         }
 
         let client = client_builder


### PR DESCRIPTION
### Motivation

- A specialized `StackOverflowFetcher` created its own reqwest client and followed redirects without using the repository's DNS/redirect validation, weakening the default SSRF/egress protections for matching Stack Exchange URLs. 
- Restore the same resolve-then-validate and redirect constraints used by the `DefaultFetcher` while preserving the specialized fetcher's behavior.

### Description

- Disable automatic redirect following for Stack Exchange API requests by using `redirect(reqwest::redirect::Policy::none())` for the API client. 
- Add constants for the API host/port (`api.stackexchange.com:443`) and use `options.dns_policy.resolve_and_validate` when `dns_policy.block_private` is enabled. 
- Pin the validated DNS result with `ClientBuilder::resolve` so the client connects only to the checked IP address. 
- Keep existing behaviors such as `no_proxy()` when `respect_proxy_env` is false and maintain API request/response handling and formatting logic.

### Testing

- Ran formatting with `cargo fmt --all`, which completed successfully. 
- Ran targeted tests with `cargo test -p fetchkit stackoverflow`, and the fetcher tests passed (`9 passed; 0 failed`). 
- Built and ran the test profile used by CI during the change, and the test run finished with no failing tests in the modified area.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09eb463a44832ba13825b071d470b6)