### PR TITLE
fix(fetchers): enforce max_body_size in GitHub issue fetcher

### DIFF
--- a/crates/fetchkit/src/fetchers/github_issue.rs
+++ b/crates/fetchkit/src/fetchers/github_issue.rs
@@ -19,6 +19,7 @@ const API_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Max comments to fetch (first page)
 const MAX_COMMENTS: usize = 100;
+const DEFAULT_MAX_BODY_SIZE: usize = 5 * 1024 * 1024; // 5MB
 
 /// GitHub issue/PR fetcher
 ///
@@ -291,7 +292,12 @@ impl Fetcher for GitHubIssueFetcher {
             "github_issue"
         };
 
-        let content = format_issue_response(&issue, pr_data.as_ref(), comments.as_deref());
+        let max_body_size = options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE);
+        let (content, truncated) = truncate_to_max_bytes(
+            format_issue_response(&issue, pr_data.as_ref(), comments.as_deref()),
+            max_body_size,
+        );
+        let size = u64::try_from(content.len()).unwrap_or(u64::MAX);
 
         Ok(FetchResponse {
             url: request.url.clone(),
@@ -299,9 +305,28 @@ impl Fetcher for GitHubIssueFetcher {
             content_type: Some("text/markdown".to_string()),
             format: Some(format.to_string()),
             content: Some(content),
+            size: Some(size),
+            truncated: Some(truncated),
             ..Default::default()
         })
     }
+}
+
+fn truncate_to_max_bytes(mut s: String, max_bytes: usize) -> (String, bool) {
+    if s.len() <= max_bytes {
+        return (s, false);
+    }
+
+    if max_bytes == 0 {
+        return (String::new(), true);
+    }
+
+    let mut end = max_bytes.min(s.len());
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+    (s, true)
 }
 
 fn format_issue_response(
@@ -566,5 +591,16 @@ mod tests {
         assert!(output.contains("+50 -10 across 3 files"));
         assert!(output.contains("**Merged:**"));
         assert!(output.contains("**Review comments:** 2"));
+    }
+
+    #[test]
+    fn test_truncate_to_max_bytes() {
+        let (s, truncated) = truncate_to_max_bytes("hello world".to_string(), 5);
+        assert_eq!(s, "hello");
+        assert!(truncated);
+
+        let (s, truncated) = truncate_to_max_bytes("éclair".to_string(), 1);
+        assert_eq!(s, "");
+        assert!(truncated);
     }
 }


### PR DESCRIPTION
### Motivation

- Close a size-limit bypass where `GitHubIssueFetcher` consumed GitHub API JSON with unbounded `json()` and returned full issue and comment bodies, ignoring `FetchOptions.max_body_size` and `FetchResponse.truncated`.

### Description

- Apply `FetchOptions.max_body_size` (with a `5 MiB` fallback) to the formatted GitHub issue/PR markdown before returning it via the fetcher by truncating the output to the configured cap.
- Add a UTF-8-safe truncation helper `truncate_to_max_bytes` to avoid splitting multibyte characters when trimming output.
- Populate `FetchResponse.size` and `FetchResponse.truncated` to reflect the returned content length and whether truncation occurred.
- Add unit test coverage for the truncation helper (including multibyte boundary behavior) and keep existing formatting/fetch behavior intact.

### Testing

- Ran formatter: `cargo fmt --all` (completed successfully).
- Ran targeted tests: `cargo test -p fetchkit github_issue -- --nocapture`, and the fetcher tests passed (`11 passed; 0 failed`).
- All modified-unit tests covering truncation and formatting succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0f9c88832b848321e3664420bf)