### PR TITLE
fix(fetchers): enforce policy on GitHub API redirect target

### DIFF
--- a/crates/fetchkit/src/fetchers/github_code.rs
+++ b/crates/fetchkit/src/fetchers/github_code.rs
@@ -176,9 +176,11 @@ impl Fetcher for GitHubCodeFetcher {
             "https://api.github.com/repos/{}/{}/contents/{}?ref={}",
             parsed.owner, parsed.repo, parsed.path, parsed.git_ref
         );
+        let parsed_api_url = Url::parse(&api_url).map_err(|_| FetchError::InvalidUrlScheme)?;
+        options.validate_url(&parsed_api_url)?;
 
         let response = client
-            .get(&api_url)
+            .get(parsed_api_url)
             .header(USER_AGENT, ua_header)
             .header(ACCEPT, accept_header)
             .send()


### PR DESCRIPTION
### Motivation
- Close a policy-enforcement bypass where `GitHubCodeFetcher` validated only the original `github.com` URL but then issued an unvalidated outbound request to `https://api.github.com:443`, allowing host/port or prefix policies to be bypassed.

### Description
- Parse the constructed GitHub API URL into a `Url`, call `options.validate_url(&parsed_api_url)`, and use `parsed_api_url` for the outbound request in `GitHubCodeFetcher::fetch`.
- The change is minimal and preserves existing behavior while applying the same `FetchOptions` host/port/prefix checks to the actual outbound endpoint.

### Testing
- Ran `cargo test -p fetchkit github_code -- --nocapture` and all `github_code` unit tests passed (`10 passed`).
- Repository remote `origin` was not configured in this environment, so no rebase against `origin/main` was performed in-session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec10403c832bb9dc61f6aafab800)