### PR TITLE
fix(fetchkit): re-sign bot-auth headers on redirect hops

### DIFF
--- a/crates/fetchkit/src/fetchers/default.rs
+++ b/crates/fetchkit/src/fetchers/default.rs
@@ -220,7 +220,6 @@ impl Fetcher for DefaultFetcher {
 
         let headers = build_headers(options, accept, request);
         let parsed_url = url::Url::parse(&request.url).map_err(|_| FetchError::InvalidUrlScheme)?;
-        let headers = apply_bot_auth_if_enabled(headers, options, &parsed_url);
 
         let reqwest_method = match method {
             HttpMethod::Get => reqwest::Method::GET,
@@ -401,7 +400,6 @@ impl Fetcher for DefaultFetcher {
 
         let headers = build_headers(options, "*/*", request);
         let parsed_url = url::Url::parse(&request.url).map_err(|_| FetchError::InvalidUrlScheme)?;
-        let headers = apply_bot_auth_if_enabled(headers, options, &parsed_url);
 
         let reqwest_method = match method {
             HttpMethod::Get => reqwest::Method::GET,
@@ -479,7 +477,8 @@ pub(crate) async fn send_request_following_redirects(
     let mut redirect_chain = Vec::new();
 
     for redirect_count in 0..=MAX_REDIRECTS {
-        let client = build_client_for_url(&current_url, headers.clone(), options, timeout)?;
+        let request_headers = apply_bot_auth_if_enabled(headers.clone(), options, &current_url);
+        let client = build_client_for_url(&current_url, request_headers, options, timeout)?;
         let response = client
             .request(method.clone(), current_url.clone())
             .send()


### PR DESCRIPTION
### Motivation
- Prevent replay/leakage of bot-auth `Signature`/`Signature-Input` headers that were generated once for the initial authority and forwarded unchanged to subsequent redirect hops, which can expose replayable credentials to cross-host redirects.

### Description
- Stop precomputing and attaching bot-auth headers before manual redirect handling in `fetch()` and `fetch_to_file()` by removing the one-time `apply_bot_auth_if_enabled(...)` calls there.
- Recompute and apply bot-auth headers per hop inside `send_request_following_redirects()` by calling `apply_bot_auth_if_enabled(headers.clone(), options, &current_url)` before building the `reqwest` client for each request.
- Preserve non-bot-auth behavior and keep changes feature-gated so behavior is unchanged when the `bot-auth` feature is disabled.

### Testing
- Ran `cargo test -p fetchkit --features bot-auth` and all crate tests passed, including `bot_auth` unit tests and `fetchers::default` tests that assert headers are sent (10 tests ran and passed). 
- Ran `cargo fmt --all` with no formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0ff448832bae5d433321f7aec5)