### PR TITLE
fix(fetchers): enforce twitter fetch hardening limits

### DIFF
--- a/crates/fetchkit/src/fetchers/twitter.rs
+++ b/crates/fetchkit/src/fetchers/twitter.rs
@@ -9,6 +9,7 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
+use crate::fetchers::default::{read_body_with_timeout, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
@@ -417,7 +418,7 @@ fn build_client(
     let mut builder = reqwest::Client::builder()
         .connect_timeout(API_TIMEOUT)
         .timeout(API_TIMEOUT)
-        .redirect(reqwest::redirect::Policy::limited(5));
+        .redirect(reqwest::redirect::Policy::none());
 
     if !options.respect_proxy_env {
         builder = builder.no_proxy();
@@ -539,10 +540,11 @@ impl TwitterFetcher {
             )));
         }
 
-        let body = response
-            .text()
-            .await
-            .map_err(|e| FetchError::FetcherError(format!("Failed to read response: {}", e)))?;
+        let max_body_size = options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE);
+        let (body, _truncated) =
+            read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
+
+        let body = String::from_utf8_lossy(&body);
 
         if body.is_empty() {
             return Err(FetchError::FetcherError(
@@ -550,7 +552,7 @@ impl TwitterFetcher {
             ));
         }
 
-        serde_json::from_str(&body).map_err(|e| {
+        serde_json::from_str(body.as_ref()).map_err(|e| {
             FetchError::FetcherError(format!("Failed to parse syndication response: {}", e))
         })
     }
@@ -580,7 +582,11 @@ impl TwitterFetcher {
             )));
         }
 
-        response.json().await.map_err(|e| {
+        let max_body_size = options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE);
+        let (body, _truncated) =
+            read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
+
+        serde_json::from_slice(&body).map_err(|e| {
             FetchError::FetcherError(format!("Failed to parse oEmbed response: {}", e))
         })
     }


### PR DESCRIPTION
### Motivation
- Close a hardening bypass where `TwitterFetcher` followed upstream redirects and buffered API responses without honoring `FetchOptions` limits, which could enable SSRF or large-body exhaustion for Twitter/X syndication and oEmbed responses.

### Description
- Disable automatic redirect following for the Twitter-specific client by using `reqwest::redirect::Policy::none()` to avoid unvalidated redirect hops. 
- Enforce configured body-size and timeout limits by replacing `response.text()` / `response.json()` with the shared streaming helper `read_body_with_timeout(response, BODY_TIMEOUT, max_size)` and fall back to `DEFAULT_MAX_BODY_SIZE` when `options.max_body_size` is unset. 
- Parse syndication JSON via `serde_json::from_str` on the bounded buffer (converted to UTF-8 lossily) and parse oEmbed via `serde_json::from_slice` on the bounded bytes, and add the `use` import for the helper symbols.

### Testing
- Ran formatter with `cargo fmt --all` which completed successfully. 
- Ran the targeted Rust unit tests with `cargo test -p fetchkit twitter::tests -- --nocapture` and the twitter fetcher tests all passed (20 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0fe35c832bacc8c21d36de1fae)