### PR TITLE
fix(fetchkit): tighten content-type checks for markdown and text

### DIFF
--- a/crates/fetchkit/src/convert.rs
+++ b/crates/fetchkit/src/convert.rs
@@ -6,7 +6,8 @@ use crate::types::{PageLink, PageMetadata};
 pub fn is_markdown_content_type(content_type: &Option<String>) -> bool {
     content_type
         .as_deref()
-        .map(|ct| ct.to_lowercase().contains("text/markdown"))
+        .and_then(|ct| ct.split(';').next())
+        .map(|media_type| media_type.trim().eq_ignore_ascii_case("text/markdown"))
         .unwrap_or(false)
 }
 
@@ -14,7 +15,8 @@ pub fn is_markdown_content_type(content_type: &Option<String>) -> bool {
 pub fn is_plain_text_content_type(content_type: &Option<String>) -> bool {
     content_type
         .as_deref()
-        .map(|ct| ct.to_lowercase().contains("text/plain"))
+        .and_then(|ct| ct.split(';').next())
+        .map(|media_type| media_type.trim().eq_ignore_ascii_case("text/plain"))
         .unwrap_or(false)
 }
 
@@ -1221,6 +1223,9 @@ mod tests {
             "text/markdown; charset=utf-8".to_string()
         )));
         assert!(is_markdown_content_type(&Some("Text/Markdown".to_string())));
+        assert!(!is_markdown_content_type(&Some(
+            "text/html; profile=\"text/markdown\"".to_string()
+        )));
         assert!(!is_markdown_content_type(&Some("text/html".to_string())));
         assert!(!is_markdown_content_type(&Some("text/plain".to_string())));
         assert!(!is_markdown_content_type(&None));
@@ -1233,6 +1238,9 @@ mod tests {
             "text/plain; charset=utf-8".to_string()
         )));
         assert!(is_plain_text_content_type(&Some("Text/Plain".to_string())));
+        assert!(!is_plain_text_content_type(&Some(
+            "text/html; profile=\"text/plain\"".to_string()
+        )));
         assert!(!is_plain_text_content_type(&Some("text/html".to_string())));
         assert!(!is_plain_text_content_type(&Some(
             "text/markdown".to_string()


### PR DESCRIPTION
### Motivation
- Substring-based Content-Type checks could misclassify `text/html` responses that include parameters like `profile="text/markdown"` as markdown or plain text, allowing raw HTML (including `<script>`/`iframe`) to bypass the HTML conversion sanitization.

### Description
- Change `is_markdown_content_type` and `is_plain_text_content_type` to parse only the primary media type token (the part before `;`) and compare it with `eq_ignore_ascii_case` after trimming. 
- Add regression assertions to the unit tests to ensure headers like `text/html; profile="text/markdown"` and `text/html; profile="text/plain"` are not treated as markdown/plain text. 
- This is a minimal behavioral fix that preserves existing functionality for legitimate `text/markdown` and `text/plain` media types while preventing parameter-based spoofing.

### Testing
- Ran `cargo test -p fetchkit is_markdown_content_type` and the updated `test_is_markdown_content_type` passed. 
- Ran `cargo test -p fetchkit is_plain_text_content_type` and the updated `test_is_plain_text_content_type` passed. 
- The change is limited to content-type detection and does not alter the HTML conversion code paths beyond restoring correct sanitization routing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0fdd08832b9afdf2df64aef8b9)