### PR TITLE
fix(docs): avoid printing GITHUB_TOKEN in cloud quickcheck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
 Quickcheck:
 
 ```bash
-doppler run -- env | rg 'GITHUB_TOKEN'
+doppler run -- bash -lc 'test -n "${GITHUB_TOKEN:-}" && echo GITHUB_TOKEN present'
 doppler run -- bash -lc 'GH_TOKEN="$GITHUB_TOKEN" gh auth status'
 ```
 


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of `GITHUB_TOKEN` in cloud-agent transcripts and logs by replacing a quickcheck that printed secret values.

### Description
- Update `AGENTS.md` quickcheck to use a presence-only test: replace `doppler run -- env | rg 'GITHUB_TOKEN'` with `doppler run -- bash -lc 'test -n "${GITHUB_TOKEN:-}" && echo GITHUB_TOKEN present'`, keeping the existing `gh auth status` check unchanged.

### Testing
- Documentation-only change; no automated tests were modified or required locally, and the repository CI is expected to run the standard test suite on the branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0fc8fc832b97281015530f2052)