### PR TITLE
fix(ci): pin maturin version in python workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           python -m venv .venv
           . .venv/bin/activate
-          pip install maturin
+          pip install "maturin==1.8.7"
       - name: Build Python bindings
         run: |
           . .venv/bin/activate


### PR DESCRIPTION
### Motivation
- Prevent CI supply-chain execution risk by avoiding installing the latest unpinned `maturin` from PyPI in the Python example job.

### Description
- Change `.github/workflows/ci.yml` to install `maturin==1.8.7` instead of running `pip install maturin`, preserving the existing `maturin develop` step.

### Testing
- No repository unit/CI tests were run in this environment; the change was verified by inspecting `ci.yml`, viewing the diff, and committing the update locally (rebase against `origin/main` was not possible here due to no remote configured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec1013ac832b83c13bbc157b2cfc)