### PR TITLE
fix(tool): include quality fields in output schema

### DIFF
--- a/crates/fetchkit/src/tool.rs
+++ b/crates/fetchkit/src/tool.rs
@@ -746,7 +746,10 @@ fn build_output_schema() -> Value {
             "method": {"type": "string", "enum": ["HEAD"]},
             "error": {"type": "string"},
             "saved_path": {"type": "string"},
-            "bytes_written": {"type": "integer", "minimum": 0}
+            "bytes_written": {"type": "integer", "minimum": 0},
+            "word_count": {"type": "integer", "minimum": 0},
+            "redirect_chain": {"type": "array", "items": {"type": "string"}},
+            "is_paywall": {"type": "boolean"}
         },
         "required": ["url", "status_code"],
         "additionalProperties": false
@@ -1164,6 +1167,9 @@ mod tests {
         assert_eq!(input_schema["properties"]["method"]["default"], "GET");
         assert!(output_schema["properties"]["url"].is_object());
         assert!(output_schema["properties"]["status_code"].is_object());
+        assert!(output_schema["properties"]["word_count"].is_object());
+        assert!(output_schema["properties"]["redirect_chain"].is_object());
+        assert!(output_schema["properties"]["is_paywall"].is_object());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- The `FetchResponse` now serializes quality fields (`word_count`, `redirect_chain`, `is_paywall`) but the tool's advertised JSON output schema had `"additionalProperties": false` and omitted these fields, causing strict consumers to reject otherwise valid responses.

### Description

- Add `word_count`, `redirect_chain`, and `is_paywall` to the `build_output_schema()` properties so the schema matches serialized `FetchResponse` output.
- Extend the `test_tool_schemas` unit test to assert those three properties exist in the output schema.
- Minor formatting applied via `cargo fmt` as part of the change surface.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p fetchkit test_tool_schemas` and the `test_tool_schemas` assertion passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ec0fc6fc832bb331fa43d299fb73)