### PR TITLE
fix(ci): avoid shell interpolation of release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,11 +30,15 @@ jobs:
           rustup default stable
 
       - name: Verify version matches tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG_VERSION="${{ inputs.release_tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG_VERSION="$INPUT_RELEASE_TAG"
           else
-            TAG_VERSION="${{ github.event.release.tag_name }}"
+            TAG_VERSION="$RELEASE_TAG_NAME"
           fi
           if [ -z "$TAG_VERSION" ]; then
             echo "Error: release tag is required"


### PR DESCRIPTION
### Motivation
- Prevent command injection where `${{ inputs.release_tag }}` and `github.event.release.tag_name` were interpolated directly into a `run:` shell block for manual `workflow_dispatch`, which could allow crafted tag names to execute commands before `cargo publish`.

### Description
- Move `github.event_name`, `inputs.release_tag`, and `github.event.release.tag_name` into the step `env` as `EVENT_NAME`, `INPUT_RELEASE_TAG`, and `RELEASE_TAG_NAME` in `.github/workflows/publish.yml`.
- Read those environment variables inside the `run:` script instead of embedding GitHub expressions into shell source, preserving the existing version verification and `cargo publish` behavior.

### Testing
- Attempted to rebase on `origin/main` locally but it failed because no `origin` remote is configured in this environment.
- No unit or integration tests were changed or required for this workflow-only fix; CI will validate the workflow and run the repository test suite after merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0227e0d8832b807e2a59a0bab98c)