### PR TITLE
fix(cli): quote YAML frontmatter scalar values

### DIFF
--- a/crates/fetchkit-cli/src/main.rs
+++ b/crates/fetchkit-cli/src/main.rs
@@ -234,25 +234,29 @@ fn print_md_with_frontmatter(response: &fetchkit::FetchResponse) {
     writeln_safe(&format_md_with_frontmatter(response));
 }
 
+fn yaml_quote(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
 /// Format response as markdown with YAML frontmatter
 fn format_md_with_frontmatter(response: &fetchkit::FetchResponse) -> String {
     let mut output = String::new();
 
     // Build frontmatter
     output.push_str("---\n");
-    output.push_str(&format!("url: {}\n", response.url));
+    output.push_str(&format!("url: {}\n", yaml_quote(&response.url)));
     output.push_str(&format!("status_code: {}\n", response.status_code));
     if let Some(ref ct) = response.content_type {
-        output.push_str(&format!("source_content_type: {}\n", ct));
+        output.push_str(&format!("source_content_type: {}\n", yaml_quote(ct)));
     }
     if let Some(size) = response.size {
         output.push_str(&format!("source_size: {}\n", size));
     }
     if let Some(ref lm) = response.last_modified {
-        output.push_str(&format!("last_modified: {}\n", lm));
+        output.push_str(&format!("last_modified: {}\n", yaml_quote(lm)));
     }
     if let Some(ref filename) = response.filename {
-        output.push_str(&format!("filename: {}\n", filename));
+        output.push_str(&format!("filename: {}\n", yaml_quote(filename)));
     }
     if let Some(truncated) = response.truncated {
         if truncated {
@@ -302,9 +306,9 @@ mod tests {
         let output = format_md_with_frontmatter(&response);
 
         assert!(output.starts_with("---\n"));
-        assert!(output.contains("url: https://example.com\n"));
+        assert!(output.contains("url: \"https://example.com\"\n"));
         assert!(output.contains("status_code: 200\n"));
-        assert!(output.contains("source_content_type: text/html\n"));
+        assert!(output.contains("source_content_type: \"text/html\"\n"));
         assert!(output.contains("---\n# Hello World"));
     }
 
@@ -325,8 +329,8 @@ mod tests {
         let output = format_md_with_frontmatter(&response);
 
         assert!(output.contains("source_size: 1234\n"));
-        assert!(output.contains("last_modified: Wed, 01 Jan 2025 00:00:00 GMT\n"));
-        assert!(output.contains("filename: page.html\n"));
+        assert!(output.contains("last_modified: \"Wed, 01 Jan 2025 00:00:00 GMT\"\n"));
+        assert!(output.contains("filename: \"page.html\"\n"));
         assert!(output.contains("truncated: true\n"));
     }
 
@@ -361,5 +365,22 @@ mod tests {
 
         // truncated: false should not appear
         assert!(!output.contains("truncated"));
+    }
+
+    #[test]
+    fn test_format_md_quotes_untrusted_scalars() {
+        let response = FetchResponse {
+            url: "https://example.com/a\nforged: true".to_string(),
+            status_code: 200,
+            filename: Some("*alias".to_string()),
+            content: Some("ok".to_string()),
+            ..Default::default()
+        };
+
+        let output = format_md_with_frontmatter(&response);
+
+        assert!(output.contains("url: \"https://example.com/a\\nforged: true\"\n"));
+        assert!(output.contains("filename: \"*alias\"\n"));
+        assert!(!output.contains("\nforged: true\n"));
     }
 }

--- a/crates/fetchkit-cli/src/mcp.rs
+++ b/crates/fetchkit-cli/src/mcp.rs
@@ -197,19 +197,19 @@ fn format_md_with_frontmatter(response: &fetchkit::FetchResponse) -> String {
 
     // Build frontmatter
     output.push_str("---\n");
-    output.push_str(&format!("url: {}\n", response.url));
+    output.push_str(&format!("url: {}\n", yaml_quote(&response.url)));
     output.push_str(&format!("status_code: {}\n", response.status_code));
     if let Some(ref ct) = response.content_type {
-        output.push_str(&format!("source_content_type: {}\n", ct));
+        output.push_str(&format!("source_content_type: {}\n", yaml_quote(ct)));
     }
     if let Some(size) = response.size {
         output.push_str(&format!("source_size: {}\n", size));
     }
     if let Some(ref lm) = response.last_modified {
-        output.push_str(&format!("last_modified: {}\n", lm));
+        output.push_str(&format!("last_modified: {}\n", yaml_quote(lm)));
     }
     if let Some(ref filename) = response.filename {
-        output.push_str(&format!("filename: {}\n", filename));
+        output.push_str(&format!("filename: {}\n", yaml_quote(filename)));
     }
     if let Some(truncated) = response.truncated {
         if truncated {
@@ -226,6 +226,10 @@ fn format_md_with_frontmatter(response: &fetchkit::FetchResponse) -> String {
     }
 
     output
+}
+
+fn yaml_quote(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
 }
 
 /// Run the MCP server over stdio

--- a/crates/fetchkit-cli/tests/cli_integration.rs
+++ b/crates/fetchkit-cli/tests/cli_integration.rs
@@ -38,7 +38,7 @@ fn test_fetch_markdown_output() {
         "Expected YAML frontmatter, got: {}",
         &stdout[..80.min(stdout.len())]
     );
-    assert!(stdout.contains("url: https://example.com"));
+    assert!(stdout.contains("url: \"https://example.com"));
     assert!(stdout.contains("status_code: 200"));
     assert!(stdout.contains("source_content_type:"));
 


### PR DESCRIPTION
### Motivation
- Prevent frontmatter injection and parsing corruption by ensuring untrusted strings emitted in the markdown YAML frontmatter (request URL and response metadata) are safely quoted and escaped instead of concatenated raw.

### Description
- Added a small `yaml_quote` helper that uses JSON string escaping to safely quote scalar values and returns a valid YAML string representation. 
- Applied `yaml_quote` to the `url`, `source_content_type`, `last_modified`, and `filename` fields in the CLI formatter in `crates/fetchkit-cli/src/main.rs` and the MCP formatter in `crates/fetchkit-cli/src/mcp.rs`. 
- Updated unit tests in `crates/fetchkit-cli/src/main.rs` to expect quoted scalars and added a regression test that verifies newline and YAML-special payloads remain quoted and do not inject frontmatter keys. 
- Changes are minimal and preserve existing markdown-first output while hardening frontmatter integrity.

### Testing
- Ran formatter: `cargo fmt --all` which completed successfully. 
- Ran unit and integration tests for the CLI: `cargo test -p fetchkit-cli` and all tests passed (including the new regression test) with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f73e4364832bad16307126684c2c)