### PR TITLE
feat(transport): pluggable HttpTransport abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pluggable HTTP transport abstraction (`HttpTransport`, `TransportRequest`, `TransportResponse`, `TransportError`, `ReqwestTransport`). A host application can route fetchkit's outbound HTTP through its own egress boundary via `FetchOptions::transport`, while fetchkit retains URL validation, DNS policy (resolve-then-check, pinned addrs), manual redirect following, bot-auth signing, and body-size/timeout caps. Default behavior is unchanged (`ReqwestTransport`).
+
 ## [0.3.0] - 2026-05-18
 
 ### Highlights

--- a/crates/fetchkit/src/client.rs
+++ b/crates/fetchkit/src/client.rs
@@ -8,11 +8,13 @@ use crate::bot_auth::BotAuthConfig;
 use crate::dns::DnsPolicy;
 use crate::error::FetchError;
 use crate::fetchers::FetcherRegistry;
+use crate::transport::{HttpTransport, ReqwestTransport};
 use crate::types::{FetchRequest, FetchResponse};
+use std::sync::Arc;
 use url::Url;
 
 /// Fetch options that can be configured via tool builder
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct FetchOptions {
     /// Custom User-Agent
     pub user_agent: Option<String>,
@@ -43,9 +45,55 @@ pub struct FetchOptions {
     /// When set, outgoing requests are signed with Ed25519.
     #[cfg(feature = "bot-auth")]
     pub bot_auth: Option<BotAuthConfig>,
+    /// Pluggable HTTP transport. When `None`, the default [`ReqwestTransport`] is used.
+    ///
+    /// A host application can supply its own transport to route fetchkit's outbound
+    /// HTTP through a dedicated egress boundary. fetchkit still performs all URL
+    /// validation, DNS policy resolution, redirect following, and content handling;
+    /// only the socket-level send is delegated.
+    pub transport: Option<Arc<dyn HttpTransport>>,
+}
+
+// Manual Debug: `transport` is a trait object that does not implement Debug.
+impl std::fmt::Debug for FetchOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("FetchOptions");
+        d.field("user_agent", &self.user_agent)
+            .field("allow_prefixes", &self.allow_prefixes)
+            .field("block_prefixes", &self.block_prefixes)
+            .field("enable_markdown", &self.enable_markdown)
+            .field("enable_text", &self.enable_text)
+            .field("dns_policy", &self.dns_policy)
+            .field("max_body_size", &self.max_body_size)
+            .field("enable_save_to_file", &self.enable_save_to_file)
+            .field("respect_proxy_env", &self.respect_proxy_env)
+            .field("allowed_ports", &self.allowed_ports)
+            .field("blocked_hosts", &self.blocked_hosts)
+            .field("same_host_redirects_only", &self.same_host_redirects_only);
+        #[cfg(feature = "bot-auth")]
+        d.field("bot_auth", &self.bot_auth);
+        d.field(
+            "transport",
+            &self
+                .transport
+                .as_ref()
+                .map(|_| "<custom>")
+                .unwrap_or("None"),
+        );
+        d.finish()
+    }
 }
 
 impl FetchOptions {
+    /// Resolve the active transport, falling back to [`ReqwestTransport`] when none
+    /// was supplied.
+    pub(crate) fn transport(&self) -> Arc<dyn HttpTransport> {
+        match &self.transport {
+            Some(t) => Arc::clone(t),
+            None => Arc::new(ReqwestTransport::new()),
+        }
+    }
+
     pub(crate) fn validate_url(&self, url: &Url) -> Result<(), FetchError> {
         self.validate_host(url)?;
         self.validate_port(url)?;

--- a/crates/fetchkit/src/dns.rs
+++ b/crates/fetchkit/src/dns.rs
@@ -81,6 +81,25 @@ impl DnsPolicy {
         }
     }
 
+    /// Produce the pinned socket addresses for a host that a transport must
+    /// connect to.
+    ///
+    /// When the policy blocks private IPs this runs resolve-then-check and returns
+    /// the validated address (TM-SSRF-001, TM-SSRF-005). When the policy is
+    /// permissive (`allow_all`) it returns an empty vec, signalling that the
+    /// transport may resolve the host itself.
+    ///
+    /// # Arguments
+    /// * `host` - Hostname to resolve
+    /// * `port` - Port to use in the returned SocketAddr
+    pub fn pinned_addrs(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>, DnsPolicyError> {
+        if !self.block_private {
+            return Ok(Vec::new());
+        }
+        let addr = self.resolve_and_validate(host, port)?;
+        Ok(vec![addr])
+    }
+
     /// Resolve a hostname and validate all resolved IPs against the policy
     ///
     /// Returns the first valid (non-blocked) socket address, or an error if

--- a/crates/fetchkit/src/fetchers/arxiv.rs
+++ b/crates/fetchkit/src/fetchers/arxiv.rs
@@ -5,12 +5,14 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
-use crate::fetchers::default::{read_body_with_timeout, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE};
+use crate::fetchers::default::{
+    read_body_with_timeout, send_request_following_redirects, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE,
+};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use std::time::Duration;
 use url::Url;
 
@@ -99,37 +101,31 @@ impl Fetcher for ArXivFetcher {
             .ok_or_else(|| FetchError::FetcherError("Not a valid arXiv URL".to_string()))?;
 
         let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-        let mut client_builder = reqwest::Client::builder()
-            .connect_timeout(API_TIMEOUT)
-            .timeout(API_TIMEOUT)
-            .redirect(reqwest::redirect::Policy::limited(3));
-
-        if !options.respect_proxy_env {
-            client_builder = client_builder.no_proxy();
-        }
-
-        let client = client_builder
-            .build()
-            .map_err(FetchError::ClientBuildError)?;
-
         let ua_header = HeaderValue::from_str(user_agent)
             .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
 
         // Fetch via arXiv API (returns Atom XML)
         let api_url = format!("https://export.arxiv.org/api/query?id_list={}", paper_id);
+        let parsed_api = Url::parse(&api_url).map_err(|_| FetchError::InvalidUrlScheme)?;
 
-        let response = client
-            .get(&api_url)
-            .header(USER_AGENT, ua_header)
-            .send()
-            .await
-            .map_err(FetchError::from_reqwest)?;
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, ua_header);
 
-        if !response.status().is_success() {
+        // THREAT[TM-SSRF-010]: manual redirect following re-validates each hop.
+        let (response, _redirect_chain) = send_request_following_redirects(
+            parsed_api,
+            reqwest::Method::GET,
+            headers,
+            options,
+            API_TIMEOUT,
+        )
+        .await?;
+
+        if !(200..300).contains(&response.status) {
             return Ok(FetchResponse {
                 url: request.url.clone(),
-                status_code: response.status().as_u16(),
-                error: Some(format!("arXiv API error: HTTP {}", response.status())),
+                status_code: response.status,
+                error: Some(format!("arXiv API error: HTTP {}", response.status)),
                 ..Default::default()
             });
         }

--- a/crates/fetchkit/src/fetchers/default.rs
+++ b/crates/fetchkit/src/fetchers/default.rs
@@ -15,6 +15,7 @@ use crate::convert::{
 use crate::error::FetchError;
 use crate::fetchers::Fetcher;
 use crate::file_saver::FileSaver;
+use crate::transport::{BodyStream, TransportMethod, TransportRequest, TransportResponse};
 use crate::types::{FetchRequest, FetchResponse, HttpMethod};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
@@ -24,6 +25,43 @@ use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_DISPOSITION, LOCAT
 use std::time::Duration;
 use tracing::{debug, error, warn};
 use url::Url;
+
+/// Look up a header value (case-insensitive) from a transport response's header list.
+pub(crate) fn header_value<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v.as_str())
+}
+
+/// Convert a reqwest `HeaderMap` into the transport's `(name, value)` header list.
+/// Headers whose value is not valid UTF-8 are dropped (fetchkit only sets UTF-8 headers).
+fn headers_to_pairs(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|v| (name.as_str().to_string(), v.to_string()))
+        })
+        .collect()
+}
+
+/// Resolve the policy-pinned socket addresses for a URL (TM-SSRF-001/005).
+pub(crate) fn pinned_addrs_for_url(
+    url: &Url,
+    options: &FetchOptions,
+) -> Result<Vec<std::net::SocketAddr>, FetchError> {
+    let Some(host) = url.host_str() else {
+        return Ok(Vec::new());
+    };
+    let port = url.port_or_known_default().unwrap_or(80);
+    options
+        .dns_policy
+        .pinned_addrs(host, port)
+        .map_err(|_| FetchError::BlockedUrl)
+}
 
 /// Binary content type prefixes
 const BINARY_PREFIXES: &[&str] = &[
@@ -163,24 +201,12 @@ struct ResponseMeta {
     filename: Option<String>,
 }
 
-fn extract_response_meta(headers: &HeaderMap, url: &str) -> ResponseMeta {
+fn extract_response_meta(headers: &[(String, String)], url: &str) -> ResponseMeta {
     ResponseMeta {
-        content_type: headers
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string()),
-        last_modified: headers
-            .get("last-modified")
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string()),
-        etag: headers
-            .get("etag")
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string()),
-        content_length: headers
-            .get("content-length")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse().ok()),
+        content_type: header_value(headers, "content-type").map(|s| s.to_string()),
+        last_modified: header_value(headers, "last-modified").map(|s| s.to_string()),
+        etag: header_value(headers, "etag").map(|s| s.to_string()),
+        content_length: header_value(headers, "content-length").and_then(|s| s.parse().ok()),
         filename: extract_filename(headers, url),
     }
 }
@@ -236,9 +262,9 @@ impl Fetcher for DefaultFetcher {
         )
         .await?;
 
-        let status_code = response.status().as_u16();
-        let final_url = response.url().to_string();
-        let meta = extract_response_meta(response.headers(), &final_url);
+        let status_code = response.status;
+        let final_url = response.url.to_string();
+        let meta = extract_response_meta(&response.headers, &final_url);
 
         // Handle 304 Not Modified (conditional request response)
         if status_code == 304 {
@@ -416,9 +442,9 @@ impl Fetcher for DefaultFetcher {
         )
         .await?;
 
-        let status_code = response.status().as_u16();
-        let final_url = response.url().to_string();
-        let meta = extract_response_meta(response.headers(), &final_url);
+        let status_code = response.status;
+        let final_url = response.url.to_string();
+        let meta = extract_response_meta(&response.headers, &final_url);
 
         // HEAD request — return metadata only
         if method == HttpMethod::Head {
@@ -466,24 +492,42 @@ impl Fetcher for DefaultFetcher {
 }
 
 /// Returns `(response, redirect_chain)` where redirect_chain lists intermediate URLs.
+///
+/// Performs manual, per-hop-validated redirect following (TM-SSRF-010). Each hop is
+/// resolved via DNS policy (producing pinned addrs) and executed through the
+/// configured [`HttpTransport`]; only the socket send is delegated to the transport.
 pub(crate) async fn send_request_following_redirects(
     initial_url: Url,
     method: reqwest::Method,
     headers: HeaderMap,
     options: &FetchOptions,
     timeout: Duration,
-) -> Result<(reqwest::Response, Vec<String>), FetchError> {
+) -> Result<(TransportResponse, Vec<String>), FetchError> {
+    let transport = options.transport();
+    let transport_method = if method == reqwest::Method::HEAD {
+        TransportMethod::Head
+    } else {
+        TransportMethod::Get
+    };
     let mut current_url = initial_url;
     let mut redirect_chain = Vec::new();
 
     for redirect_count in 0..=MAX_REDIRECTS {
+        // THREAT[TM-AUTH]: re-sign bot-auth headers per hop so each authority is covered.
         let request_headers = apply_bot_auth_if_enabled(headers.clone(), options, &current_url);
-        let client = build_client_for_url(&current_url, request_headers, options, timeout)?;
-        let response = client
-            .request(method.clone(), current_url.clone())
-            .send()
-            .await
-            .map_err(FetchError::from_reqwest)?;
+        // THREAT[TM-SSRF-001]/[TM-SSRF-005]: resolve-then-check produces the pinned addrs
+        // the transport must connect to.
+        let pinned_addrs = pinned_addrs_for_url(&current_url, options)?;
+
+        let req = TransportRequest {
+            method: transport_method,
+            url: current_url.clone(),
+            headers: headers_to_pairs(&request_headers),
+            timeout: Some(timeout),
+            pinned_addrs,
+            respect_proxy_env: options.respect_proxy_env,
+        };
+        let response = transport.execute(req).await?;
 
         let Some(next_url) = redirect_target(&current_url, &response, options)? else {
             return Ok((response, redirect_chain));
@@ -507,60 +551,76 @@ pub(crate) async fn send_request_following_redirects(
     unreachable!("redirect loop must return before exhausting iterations");
 }
 
-fn build_client_for_url(
-    url: &Url,
+/// Execute a single (non-redirect-following) request through the configured transport.
+///
+/// Shared by specialized fetchers that issue simple API GETs to hardcoded hosts.
+/// DNS policy resolution against `pin_host`/`pin_port` produces the pinned addrs the
+/// transport must connect to (TM-SSRF-001/005). Bot-auth headers are applied for the
+/// request URL's authority. The transport never follows redirects.
+///
+/// `pin_host`/`pin_port` are the hardcoded API host/port (so DNS pinning matches the
+/// host the URL will actually connect to). They normally equal the URL's host/port.
+pub(crate) async fn transport_request(
+    url: Url,
+    method: reqwest::Method,
     headers: HeaderMap,
     options: &FetchOptions,
     timeout: Duration,
-) -> Result<reqwest::Client, FetchError> {
-    // THREAT[TM-NET-003]: New client per request prevents connection-pool state leakage
-    let mut client_builder = reqwest::Client::builder()
-        .default_headers(headers)
-        .connect_timeout(timeout)
-        .timeout(timeout)
-        .redirect(reqwest::redirect::Policy::none());
+    pin_host: &str,
+    pin_port: u16,
+) -> Result<TransportResponse, FetchError> {
+    let transport = options.transport();
+    let transport_method = if method == reqwest::Method::HEAD {
+        TransportMethod::Head
+    } else {
+        TransportMethod::Get
+    };
+    // THREAT[TM-AUTH]: sign for the target authority before handing to the transport.
+    let request_headers = apply_bot_auth_if_enabled(headers, options, &url);
+    // THREAT[TM-SSRF-001]/[TM-SSRF-005]: resolve-then-check the API host; pin the result.
+    let pinned_addrs = options
+        .dns_policy
+        .pinned_addrs(pin_host, pin_port)
+        .map_err(|_| FetchError::BlockedUrl)?;
 
-    if !options.respect_proxy_env {
-        // THREAT[TM-NET-004]: Ignore ambient proxy env by default in shared runtimes.
-        client_builder = client_builder.no_proxy();
-    }
+    let req = TransportRequest {
+        method: transport_method,
+        url,
+        headers: headers_to_pairs(&request_headers),
+        timeout: Some(timeout),
+        pinned_addrs,
+        respect_proxy_env: options.respect_proxy_env,
+    };
+    Ok(transport.execute(req).await?)
+}
 
-    if options.dns_policy.block_private {
-        if let Some(host) = url.host_str() {
-            let port = url.port_or_known_default().unwrap_or(80);
-            let validated_addr = options
-                .dns_policy
-                .resolve_and_validate(host, port)
-                .map_err(|_| FetchError::BlockedUrl)?;
-            // THREAT[TM-SSRF-001]: Resolve-then-check — validate resolved IP before connecting.
-            // THREAT[TM-SSRF-005]: Pin DNS resolution to prevent DNS rebinding attacks.
-            client_builder = client_builder.resolve(host, validated_addr);
-        }
-    }
-
-    client_builder.build().map_err(FetchError::ClientBuildError)
+/// Read an entire transport response body as bytes, applying the body timeout and
+/// `max_body_size` cap. Returns the bytes (truncation flag discarded — callers that
+/// need it should use [`read_body_with_timeout`] directly).
+pub(crate) async fn read_full_body(
+    response: TransportResponse,
+    options: &FetchOptions,
+) -> Result<Bytes, FetchError> {
+    let max_body_size = options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE);
+    let (body, _truncated) = read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
+    Ok(body)
 }
 
 fn redirect_target(
     base_url: &Url,
-    response: &reqwest::Response,
+    response: &TransportResponse,
     options: &FetchOptions,
 ) -> Result<Option<Url>, FetchError> {
     // 304 Not Modified is in the 3xx range but is not a redirect
-    if !response.status().is_redirection() || response.status().as_u16() == 304 {
+    let status = response.status;
+    let is_redirection = (300..400).contains(&status);
+    if !is_redirection || status == 304 {
         return Ok(None);
     }
 
-    let location = response
-        .headers()
-        .get(LOCATION)
-        .ok_or_else(|| {
-            FetchError::RequestError("redirect response missing Location header".to_string())
-        })?
-        .to_str()
-        .map_err(|_| {
-            FetchError::RequestError("redirect Location header is not valid UTF-8".to_string())
-        })?;
+    let location = header_value(&response.headers, LOCATION.as_str()).ok_or_else(|| {
+        FetchError::RequestError("redirect response missing Location header".to_string())
+    })?;
 
     let next_url = base_url.join(location).map_err(|_| {
         FetchError::RequestError("redirect Location is not a valid URL".to_string())
@@ -585,13 +645,11 @@ fn is_binary_content_type(content_type: &str) -> bool {
 }
 
 /// Extract filename from Content-Disposition header or URL
-fn extract_filename(headers: &HeaderMap, url: &str) -> Option<String> {
+fn extract_filename(headers: &[(String, String)], url: &str) -> Option<String> {
     // Try Content-Disposition header first
-    if let Some(disposition) = headers.get(CONTENT_DISPOSITION) {
-        if let Ok(value) = disposition.to_str() {
-            if let Some(filename) = parse_content_disposition_filename(value) {
-                return Some(filename);
-            }
+    if let Some(value) = header_value(headers, CONTENT_DISPOSITION.as_str()) {
+        if let Some(filename) = parse_content_disposition_filename(value) {
+            return Some(filename);
         }
     }
 
@@ -642,12 +700,23 @@ fn parse_content_disposition_filename(value: &str) -> Option<String> {
 // THREAT[TM-DOS-001]: Configurable max body size prevents unbounded memory usage
 // THREAT[TM-DOS-003]: Decompressed size is checked, catching gzip/brotli bombs
 pub(crate) async fn read_body_with_timeout(
-    response: reqwest::Response,
+    response: TransportResponse,
+    timeout: Duration,
+    max_size: usize,
+) -> Result<(Bytes, bool), FetchError> {
+    read_body_stream_with_timeout(response.body, timeout, max_size).await
+}
+
+/// Read a boxed transport body stream with timeout and size limit.
+///
+/// Splitting this out from [`read_body_with_timeout`] lets the transport's streaming
+/// body drive the same caps without depending on `reqwest::Response`.
+pub(crate) async fn read_body_stream_with_timeout(
+    mut stream: BodyStream,
     timeout: Duration,
     max_size: usize,
 ) -> Result<(Bytes, bool), FetchError> {
     let mut body = Vec::new();
-    let mut stream = response.bytes_stream();
     let deadline = tokio::time::Instant::now() + timeout;
 
     loop {
@@ -673,7 +742,7 @@ pub(crate) async fn read_body_with_timeout(
                     Some(Err(e)) => {
                         error!("Error reading body chunk: {}", e);
                         if body.is_empty() {
-                            return Err(FetchError::from_reqwest(e));
+                            return Err(e.into());
                         }
                         return Ok((Bytes::from(body), true));
                     }
@@ -769,7 +838,7 @@ mod tests {
 
     #[test]
     fn test_extract_filename_from_url() {
-        let headers = HeaderMap::new();
+        let headers: Vec<(String, String)> = Vec::new();
         assert_eq!(
             extract_filename(&headers, "https://example.com/path/to/file.pdf"),
             Some("file.pdf".to_string())
@@ -828,46 +897,32 @@ mod tests {
         assert_eq!(response.content.as_deref(), Some("redirected"));
     }
 
-    #[tokio::test]
-    async fn test_redirect_target_handles_relative_location() {
-        let origin = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/start"))
-            .respond_with(ResponseTemplate::new(302).insert_header("location", "/final"))
-            .mount(&origin)
-            .await;
+    /// Build a synthetic redirect [`TransportResponse`] for redirect_target tests.
+    fn redirect_response(status: u16, location: &str) -> TransportResponse {
+        TransportResponse {
+            status,
+            url: Url::parse("https://origin.example/start").unwrap(),
+            headers: vec![("location".to_string(), location.to_string())],
+            body: Box::pin(futures::stream::empty()),
+        }
+    }
 
-        let client = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .unwrap();
-        let base_url = Url::parse(&format!("{}/start", origin.uri())).unwrap();
-        let response = client.get(base_url.clone()).send().await.unwrap();
+    #[test]
+    fn test_redirect_target_handles_relative_location() {
+        let base_url = Url::parse("https://origin.example/start").unwrap();
+        let response = redirect_response(302, "/final");
 
         let redirect = redirect_target(&base_url, &response, &FetchOptions::default()).unwrap();
         assert_eq!(
             redirect.unwrap(),
-            Url::parse(&format!("{}/final", origin.uri())).unwrap()
+            Url::parse("https://origin.example/final").unwrap()
         );
     }
 
-    #[tokio::test]
-    async fn test_redirect_target_rejects_non_http_location() {
-        let origin = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/start"))
-            .respond_with(
-                ResponseTemplate::new(302).insert_header("location", "file:///etc/passwd"),
-            )
-            .mount(&origin)
-            .await;
-
-        let client = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .unwrap();
-        let base_url = Url::parse(&format!("{}/start", origin.uri())).unwrap();
-        let response = client.get(base_url.clone()).send().await.unwrap();
+    #[test]
+    fn test_redirect_target_rejects_non_http_location() {
+        let base_url = Url::parse("https://origin.example/start").unwrap();
+        let response = redirect_response(302, "file:///etc/passwd");
 
         let redirect = redirect_target(&base_url, &response, &FetchOptions::default());
         assert!(matches!(redirect, Err(FetchError::InvalidUrlScheme)));

--- a/crates/fetchkit/src/fetchers/docs_site.rs
+++ b/crates/fetchkit/src/fetchers/docs_site.rs
@@ -11,8 +11,8 @@
 use crate::client::FetchOptions;
 use crate::error::FetchError;
 use crate::fetchers::default::{
-    apply_bot_auth_if_enabled, read_body_with_timeout, send_request_following_redirects,
-    BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE, TRUNCATION_MESSAGE,
+    apply_bot_auth_if_enabled, header_value, read_body_with_timeout, read_full_body,
+    send_request_following_redirects, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE, TRUNCATION_MESSAGE,
 };
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
@@ -160,18 +160,12 @@ impl Fetcher for DocsSiteFetcher {
         )
         .await?;
 
-        let status_code = response.status().as_u16();
-        let final_url = response.url().to_string();
-        let content_type = response
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
+        let status_code = response.status;
+        let final_url = response.url.to_string();
+        let content_type = header_value(&response.headers, "content-type").map(|s| s.to_string());
 
-        let body = response
-            .text()
-            .await
-            .map_err(|e| FetchError::RequestError(e.to_string()))?;
+        let body_bytes = read_full_body(response, options).await?;
+        let body = String::from_utf8_lossy(&body_bytes).into_owned();
 
         // If HTML, convert to markdown for cleaner docs consumption
         let (content, format) = if content_type
@@ -220,15 +214,11 @@ async fn fetch_llms_txt_direct(
     )
     .await?;
 
-    let status_code = response.status().as_u16();
-    let final_url = response.url().to_string();
-    let content_type = response
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
+    let status_code = response.status;
+    let final_url = response.url.to_string();
+    let content_type = header_value(&response.headers, "content-type").map(|s| s.to_string());
 
-    if !response.status().is_success() {
+    if !(200..300).contains(&status_code) {
         return Ok(FetchResponse {
             url: final_url,
             status_code,
@@ -283,24 +273,23 @@ async fn try_fetch_llms_txt(
     .await
     .ok()?;
 
-    if !response.status().is_success() {
+    if !(200..300).contains(&response.status) {
         return None;
     }
 
     // Reject HTML error pages masquerading as 200 OK
-    let content_type = response
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
+    let content_type = header_value(&response.headers, "content-type").unwrap_or("");
 
     if content_type.contains("text/html") {
         return None;
     }
 
-    let body = response.bytes().await.ok()?;
+    // Cap at one byte over the limit so the size check below still rejects oversize bodies.
+    let (body, truncated) = read_body_with_timeout(response, BODY_TIMEOUT, MAX_LLMS_TXT_SIZE + 1)
+        .await
+        .ok()?;
 
-    if body.len() > MAX_LLMS_TXT_SIZE {
+    if truncated || body.len() > MAX_LLMS_TXT_SIZE {
         return None;
     }
 

--- a/crates/fetchkit/src/fetchers/github_code.rs
+++ b/crates/fetchkit/src/fetchers/github_code.rs
@@ -5,16 +5,21 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
+use crate::fetchers::default::{read_full_body, transport_request};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use serde::Deserialize;
 use std::time::Duration;
 use url::Url;
 
 const API_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// GitHub API host and port (DNS-pinned per request).
+const GITHUB_API_HOST: &str = "api.github.com";
+const GITHUB_API_PORT: u16 = 443;
 
 /// Max file size we'll return inline (1 MB, matching GitHub contents API limit)
 const MAX_INLINE_SIZE: u64 = 1_048_576;
@@ -142,31 +147,7 @@ impl Fetcher for GitHubCodeFetcher {
         let parsed = Self::parse_url(&url)
             .ok_or_else(|| FetchError::FetcherError("Not a valid GitHub blob URL".to_string()))?;
 
-        // Build HTTP client
         let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-        let mut client_builder = reqwest::Client::builder()
-            .connect_timeout(API_TIMEOUT)
-            .timeout(API_TIMEOUT)
-            .redirect(reqwest::redirect::Policy::none());
-
-        if !options.respect_proxy_env {
-            // THREAT[TM-NET-004]: Ignore ambient proxy env by default
-            client_builder = client_builder.no_proxy();
-        }
-
-        if options.dns_policy.block_private {
-            let validated_addr = options
-                .dns_policy
-                .resolve_and_validate("api.github.com", 443)
-                .map_err(|_| FetchError::BlockedUrl)?;
-            // THREAT[TM-SSRF-010]: Pin DNS
-            client_builder = client_builder.resolve("api.github.com", validated_addr);
-        }
-
-        let client = client_builder
-            .build()
-            .map_err(FetchError::ClientBuildError)?;
-
         let ua_header = HeaderValue::from_str(user_agent)
             .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
         let accept_header = HeaderValue::from_static("application/vnd.github+json");
@@ -177,18 +158,27 @@ impl Fetcher for GitHubCodeFetcher {
             parsed.owner, parsed.repo, parsed.path, parsed.git_ref
         );
         let parsed_api_url = Url::parse(&api_url).map_err(|_| FetchError::InvalidUrlScheme)?;
+        // THREAT[TM-INPUT]: enforce host/port policy on the GitHub API subrequest (PR #131).
         options.validate_url(&parsed_api_url)?;
 
-        let response = client
-            .get(parsed_api_url)
-            .header(USER_AGENT, ua_header)
-            .header(ACCEPT, accept_header)
-            .send()
-            .await
-            .map_err(FetchError::from_reqwest)?;
+        let mut headers = HeaderMap::new();
+        headers.insert(USER_AGENT, ua_header);
+        headers.insert(ACCEPT, accept_header);
 
-        let status_code = response.status().as_u16();
-        if !response.status().is_success() {
+        // THREAT[TM-SSRF-010]: single-hop request, redirects not followed.
+        let response = transport_request(
+            parsed_api_url,
+            reqwest::Method::GET,
+            headers,
+            options,
+            API_TIMEOUT,
+            GITHUB_API_HOST,
+            GITHUB_API_PORT,
+        )
+        .await?;
+
+        let status_code = response.status;
+        if !(200..300).contains(&status_code) {
             let error_msg = if status_code == 404 {
                 format!(
                     "{}/{}:{} {} not found",
@@ -207,9 +197,8 @@ impl Fetcher for GitHubCodeFetcher {
             });
         }
 
-        let contents: GitHubContents = response
-            .json()
-            .await
+        let body = read_full_body(response, options).await?;
+        let contents: GitHubContents = serde_json::from_slice(&body)
             .map_err(|e| FetchError::FetcherError(format!("Failed to parse contents: {}", e)))?;
 
         // Handle directories (content_type == "dir")

--- a/crates/fetchkit/src/fetchers/github_issue.rs
+++ b/crates/fetchkit/src/fetchers/github_issue.rs
@@ -5,17 +5,22 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
+use crate::fetchers::default::{read_full_body, transport_request};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use serde::Deserialize;
 use std::time::Duration;
 use url::Url;
 
 /// First-byte timeout for API requests
 const API_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// GitHub API host and port (DNS-pinned per request).
+const GITHUB_API_HOST: &str = "api.github.com";
+const GITHUB_API_PORT: u16 = 443;
 
 /// Max comments to fetch (first page)
 const MAX_COMMENTS: usize = 100;
@@ -178,50 +183,44 @@ impl Fetcher for GitHubIssueFetcher {
             FetchError::FetcherError("Not a valid GitHub issue/PR URL".to_string())
         })?;
 
-        // Build HTTP client (same pattern as GitHubRepoFetcher)
+        // Same pattern as GitHubRepoFetcher: single-hop API requests, DNS pinned per call.
         let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-        let mut client_builder = reqwest::Client::builder()
-            .connect_timeout(API_TIMEOUT)
-            .timeout(API_TIMEOUT)
-            .redirect(reqwest::redirect::Policy::none());
-
-        if !options.respect_proxy_env {
-            // THREAT[TM-NET-004]: Ignore ambient proxy env by default
-            client_builder = client_builder.no_proxy();
-        }
-
-        if options.dns_policy.block_private {
-            let validated_addr = options
-                .dns_policy
-                .resolve_and_validate("api.github.com", 443)
-                .map_err(|_| FetchError::BlockedUrl)?;
-            // THREAT[TM-SSRF-010]: Pin DNS to avoid cross-host hops
-            client_builder = client_builder.resolve("api.github.com", validated_addr);
-        }
-
-        let client = client_builder
-            .build()
-            .map_err(FetchError::ClientBuildError)?;
-
         let ua_header = HeaderValue::from_str(user_agent)
             .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
         let accept_header = HeaderValue::from_static("application/vnd.github+json");
+
+        let api_headers = || {
+            let mut headers = HeaderMap::new();
+            headers.insert(USER_AGENT, ua_header.clone());
+            headers.insert(ACCEPT, accept_header.clone());
+            headers
+        };
+        let github_api_get = |url: String| {
+            let headers = api_headers();
+            async move {
+                let parsed = Url::parse(&url).map_err(|_| FetchError::InvalidUrlScheme)?;
+                transport_request(
+                    parsed,
+                    reqwest::Method::GET,
+                    headers,
+                    options,
+                    API_TIMEOUT,
+                    GITHUB_API_HOST,
+                    GITHUB_API_PORT,
+                )
+                .await
+            }
+        };
 
         // 1. Fetch issue/PR metadata (issues API works for both)
         let issue_url = format!(
             "https://api.github.com/repos/{}/{}/issues/{}",
             owner, repo, number
         );
-        let issue_response = client
-            .get(&issue_url)
-            .header(USER_AGENT, ua_header.clone())
-            .header(ACCEPT, accept_header.clone())
-            .send()
-            .await
-            .map_err(FetchError::from_reqwest)?;
+        let issue_response = github_api_get(issue_url).await?;
 
-        let status_code = issue_response.status().as_u16();
-        if !issue_response.status().is_success() {
+        let status_code = issue_response.status;
+        if !(200..300).contains(&status_code) {
             let error_msg = if status_code == 404 {
                 format!("{}/{}#{} not found", owner, repo, number)
             } else if status_code == 403 {
@@ -237,9 +236,8 @@ impl Fetcher for GitHubIssueFetcher {
             });
         }
 
-        let issue: GitHubIssueData = issue_response
-            .json()
-            .await
+        let issue_body = read_full_body(issue_response, options).await?;
+        let issue: GitHubIssueData = serde_json::from_slice(&issue_body)
             .map_err(|e| FetchError::FetcherError(format!("Failed to parse issue data: {}", e)))?;
 
         let is_pr = issue.pull_request.is_some();
@@ -250,14 +248,13 @@ impl Fetcher for GitHubIssueFetcher {
                 "https://api.github.com/repos/{}/{}/pulls/{}",
                 owner, repo, number
             );
-            match client
-                .get(&pr_url)
-                .header(USER_AGENT, ua_header.clone())
-                .header(ACCEPT, accept_header.clone())
-                .send()
-                .await
-            {
-                Ok(resp) if resp.status().is_success() => resp.json().await.ok(),
+            match github_api_get(pr_url).await {
+                Ok(resp) if (200..300).contains(&resp.status) => {
+                    match read_full_body(resp, options).await {
+                        Ok(body) => serde_json::from_slice(&body).ok(),
+                        Err(_) => None,
+                    }
+                }
                 _ => None,
             }
         } else {
@@ -270,15 +267,12 @@ impl Fetcher for GitHubIssueFetcher {
                 "https://api.github.com/repos/{}/{}/issues/{}/comments?per_page={}",
                 owner, repo, number, MAX_COMMENTS
             );
-            match client
-                .get(&comments_url)
-                .header(USER_AGENT, ua_header.clone())
-                .header(ACCEPT, accept_header.clone())
-                .send()
-                .await
-            {
-                Ok(resp) if resp.status().is_success() => {
-                    resp.json::<Vec<GitHubComment>>().await.ok()
+            match github_api_get(comments_url).await {
+                Ok(resp) if (200..300).contains(&resp.status) => {
+                    match read_full_body(resp, options).await {
+                        Ok(body) => serde_json::from_slice::<Vec<GitHubComment>>(&body).ok(),
+                        Err(_) => None,
+                    }
                 }
                 _ => None,
             }

--- a/crates/fetchkit/src/fetchers/github_repo.rs
+++ b/crates/fetchkit/src/fetchers/github_repo.rs
@@ -4,14 +4,19 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
+use crate::fetchers::default::{read_full_body, transport_request};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse, HttpMethod};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use serde::Deserialize;
 use std::time::Duration;
 use url::Url;
+
+/// GitHub API host and port (DNS-pinned per request).
+const GITHUB_API_HOST: &str = "api.github.com";
+const GITHUB_API_PORT: u16 = 443;
 
 /// First-byte timeout for API requests
 const API_TIMEOUT: Duration = Duration::from_secs(10);
@@ -176,58 +181,48 @@ impl Fetcher for GitHubRepoFetcher {
             FetchError::FetcherError("Not a valid GitHub repository URL".to_string())
         })?;
 
-        // Build HTTP client
-        // THREAT[TM-SSRF-001]: Validate DNS resolution for GitHub API host
+        // THREAT[TM-SSRF-001]: Validate DNS resolution for GitHub API host (pinned per request).
         let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-        let mut client_builder = reqwest::Client::builder()
-            .connect_timeout(API_TIMEOUT)
-            .timeout(API_TIMEOUT)
-            .redirect(reqwest::redirect::Policy::none());
+        let ua_header = HeaderValue::from_str(user_agent)
+            .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
+        let accept_header = HeaderValue::from_static("application/vnd.github+json");
 
-        if !options.respect_proxy_env {
-            // THREAT[TM-NET-004]: Ignore ambient proxy env by default in shared runtimes.
-            client_builder = client_builder.no_proxy();
-        }
-
-        if options.dns_policy.block_private {
-            let validated_addr = options
-                .dns_policy
-                .resolve_and_validate("api.github.com", 443)
-                .map_err(|_| FetchError::BlockedUrl)?;
-            // THREAT[TM-SSRF-010]: Disable redirects and pin GitHub API DNS to avoid cross-host hops.
-            client_builder = client_builder.resolve("api.github.com", validated_addr);
-        }
-
-        let client = client_builder
-            .build()
-            .map_err(FetchError::ClientBuildError)?;
+        // Headers shared by every GitHub API subrequest.
+        let api_headers = || {
+            let mut headers = HeaderMap::new();
+            headers.insert(USER_AGENT, ua_header.clone());
+            headers.insert(ACCEPT, accept_header.clone());
+            headers
+        };
 
         // Fetch repository metadata
+        // THREAT[TM-INPUT-002]/[TM-INPUT-007]: enforce allow/block prefix policy on the
+        // GitHub API subrequest URL (PR #131), not just the user-facing github.com URL.
         let repo_url = format!("https://api.github.com/repos/{}/{}", owner, repo);
         Self::validate_policy_url(&repo_url, options)?;
+        let parsed_repo_url = Url::parse(&repo_url).map_err(|_| FetchError::InvalidUrlScheme)?;
 
-        let repo_request = match request.effective_method() {
-            HttpMethod::Get => client.get(&repo_url),
-            HttpMethod::Head => client.head(&repo_url),
+        let method = match request.effective_method() {
+            HttpMethod::Get => reqwest::Method::GET,
+            HttpMethod::Head => reqwest::Method::HEAD,
         };
-        let repo_response = repo_request
-            .header(
-                USER_AGENT,
-                HeaderValue::from_str(user_agent)
-                    .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT)),
-            )
-            .header(
-                ACCEPT,
-                HeaderValue::from_static("application/vnd.github+json"),
-            )
-            .send()
-            .await
-            .map_err(FetchError::from_reqwest)?;
+        // THREAT[TM-SSRF-010]: single-hop transport request; redirects are not followed
+        // for the GitHub API to avoid cross-host hops.
+        let repo_response = transport_request(
+            parsed_repo_url,
+            method,
+            api_headers(),
+            options,
+            API_TIMEOUT,
+            GITHUB_API_HOST,
+            GITHUB_API_PORT,
+        )
+        .await?;
 
-        let status_code = repo_response.status().as_u16();
+        let status_code = repo_response.status;
 
         // Handle non-success status
-        if !repo_response.status().is_success() {
+        if !(200..300).contains(&status_code) {
             let error_msg = if status_code == 404 {
                 format!("Repository {}/{} not found", owner, repo)
             } else if status_code == 403 {
@@ -253,38 +248,41 @@ impl Fetcher for GitHubRepoFetcher {
         }
 
         // Parse repository data
-        let repo_data: GitHubRepo = repo_response
-            .json()
-            .await
+        let repo_body = read_full_body(repo_response, options).await?;
+        let repo_data: GitHubRepo = serde_json::from_slice(&repo_body)
             .map_err(|e| FetchError::FetcherError(format!("Failed to parse repo data: {}", e)))?;
 
         // Fetch README (optional - don't fail if missing)
         let readme_url = format!("https://api.github.com/repos/{}/{}/readme", owner, repo);
         Self::validate_policy_url(&readme_url, options)?;
-        let readme_content = match client
-            .get(&readme_url)
-            .header(
-                USER_AGENT,
-                HeaderValue::from_str(user_agent)
-                    .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT)),
-            )
-            .header(
-                ACCEPT,
-                HeaderValue::from_static("application/vnd.github+json"),
-            )
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => {
-                match resp.json::<GitHubReadme>().await {
-                    Ok(readme) if readme.encoding == "base64" => {
-                        // Decode base64 content
-                        decode_base64_content(&readme.content)
+        let readme_content = match Url::parse(&readme_url) {
+            Ok(parsed_readme_url) => {
+                match transport_request(
+                    parsed_readme_url,
+                    reqwest::Method::GET,
+                    api_headers(),
+                    options,
+                    API_TIMEOUT,
+                    GITHUB_API_HOST,
+                    GITHUB_API_PORT,
+                )
+                .await
+                {
+                    Ok(resp) if (200..300).contains(&resp.status) => {
+                        match read_full_body(resp, options).await {
+                            Ok(body) => match serde_json::from_slice::<GitHubReadme>(&body) {
+                                Ok(readme) if readme.encoding == "base64" => {
+                                    decode_base64_content(&readme.content)
+                                }
+                                _ => None,
+                            },
+                            Err(_) => None,
+                        }
                     }
                     _ => None,
                 }
             }
-            _ => None,
+            Err(_) => None,
         };
 
         // Format response as markdown

--- a/crates/fetchkit/src/fetchers/hackernews.rs
+++ b/crates/fetchkit/src/fetchers/hackernews.rs
@@ -5,11 +5,12 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
+use crate::fetchers::default::{read_full_body, send_request_following_redirects};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use serde::Deserialize;
 use std::time::Duration;
 use url::Url;
@@ -92,35 +93,22 @@ impl Fetcher for HackerNewsFetcher {
             .ok_or_else(|| FetchError::FetcherError("Not a valid HN URL".to_string()))?;
 
         let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-        let mut client_builder = reqwest::Client::builder()
-            .connect_timeout(API_TIMEOUT)
-            .timeout(API_TIMEOUT)
-            .redirect(reqwest::redirect::Policy::limited(3));
-
-        if !options.respect_proxy_env {
-            client_builder = client_builder.no_proxy();
-        }
-
-        let client = client_builder
-            .build()
-            .map_err(FetchError::ClientBuildError)?;
-
         let ua_header = HeaderValue::from_str(user_agent)
             .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
 
         // Fetch the item
-        let item = fetch_item(&client, &ua_header, item_id).await?;
+        let item = fetch_item(options, &ua_header, item_id).await?;
 
         // Fetch top-level comments
         let comments = if let Some(kids) = &item.kids {
             let mut comments = Vec::new();
             for &kid_id in kids.iter().take(MAX_COMMENTS) {
-                if let Ok(comment) = fetch_item(&client, &ua_header, kid_id).await {
+                if let Ok(comment) = fetch_item(options, &ua_header, kid_id).await {
                     // Fetch one level of replies
                     let replies = if let Some(reply_ids) = &comment.kids {
                         let mut replies = Vec::new();
                         for &reply_id in reply_ids.iter().take(5) {
-                            if let Ok(reply) = fetch_item(&client, &ua_header, reply_id).await {
+                            if let Ok(reply) = fetch_item(options, &ua_header, reply_id).await {
                                 replies.push(reply);
                             }
                         }
@@ -150,28 +138,35 @@ impl Fetcher for HackerNewsFetcher {
 }
 
 async fn fetch_item(
-    client: &reqwest::Client,
+    options: &FetchOptions,
     ua: &HeaderValue,
     id: u64,
 ) -> Result<HNItem, FetchError> {
     let url = format!("https://hacker-news.firebaseio.com/v0/item/{}.json", id);
+    let parsed = Url::parse(&url).map_err(|_| FetchError::InvalidUrlScheme)?;
 
-    let resp = client
-        .get(&url)
-        .header(USER_AGENT, ua.clone())
-        .send()
-        .await
-        .map_err(FetchError::from_reqwest)?;
+    let mut headers = HeaderMap::new();
+    headers.insert(USER_AGENT, ua.clone());
 
-    if !resp.status().is_success() {
+    // THREAT[TM-SSRF-010]: manual redirect following re-validates each hop.
+    let (resp, _redirect_chain) = send_request_following_redirects(
+        parsed,
+        reqwest::Method::GET,
+        headers,
+        options,
+        API_TIMEOUT,
+    )
+    .await?;
+
+    if !(200..300).contains(&resp.status) {
         return Err(FetchError::FetcherError(format!(
             "HN API error: HTTP {}",
-            resp.status()
+            resp.status
         )));
     }
 
-    resp.json()
-        .await
+    let body = read_full_body(resp, options).await?;
+    serde_json::from_slice(&body)
         .map_err(|e| FetchError::FetcherError(format!("Failed to parse HN item: {}", e)))
 }
 

--- a/crates/fetchkit/src/fetchers/package_registry.rs
+++ b/crates/fetchkit/src/fetchers/package_registry.rs
@@ -5,12 +5,14 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
-use crate::fetchers::default::{read_body_with_timeout, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE};
+use crate::fetchers::default::{
+    read_body_with_timeout, send_request_following_redirects, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE,
+};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use serde::Deserialize;
 use std::time::Duration;
 use url::Url;
@@ -178,19 +180,6 @@ impl Fetcher for PackageRegistryFetcher {
         })?;
 
         let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-        let mut client_builder = reqwest::Client::builder()
-            .connect_timeout(API_TIMEOUT)
-            .timeout(API_TIMEOUT)
-            .redirect(reqwest::redirect::Policy::limited(3));
-
-        if !options.respect_proxy_env {
-            client_builder = client_builder.no_proxy();
-        }
-
-        let client = client_builder
-            .build()
-            .map_err(FetchError::ClientBuildError)?;
-
         let ua_header = HeaderValue::from_str(user_agent)
             .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
         let max_body_size = options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE);
@@ -198,7 +187,7 @@ impl Fetcher for PackageRegistryFetcher {
         let content = match registry {
             Registry::PyPI { name, version } => {
                 fetch_pypi(
-                    &client,
+                    options,
                     &ua_header,
                     &name,
                     version.as_deref(),
@@ -207,9 +196,9 @@ impl Fetcher for PackageRegistryFetcher {
                 .await?
             }
             Registry::CratesIo { name } => {
-                fetch_crates_io(&client, &ua_header, &name, max_body_size).await?
+                fetch_crates_io(options, &ua_header, &name, max_body_size).await?
             }
-            Registry::Npm { name } => fetch_npm(&client, &ua_header, &name, max_body_size).await?,
+            Registry::Npm { name } => fetch_npm(options, &ua_header, &name, max_body_size).await?,
         };
 
         Ok(FetchResponse {
@@ -223,8 +212,45 @@ impl Fetcher for PackageRegistryFetcher {
     }
 }
 
+/// Issue a single registry API GET through the configured transport, with manual
+/// per-hop redirect validation (TM-SSRF-010). Returns the capped body bytes.
+async fn registry_get(
+    options: &FetchOptions,
+    ua: &HeaderValue,
+    accept: Option<HeaderValue>,
+    api_url: &str,
+    max_body_size: usize,
+    api_name: &str,
+) -> Result<bytes::Bytes, FetchError> {
+    let parsed = Url::parse(api_url).map_err(|_| FetchError::InvalidUrlScheme)?;
+    let mut headers = HeaderMap::new();
+    headers.insert(USER_AGENT, ua.clone());
+    if let Some(accept) = accept {
+        headers.insert(ACCEPT, accept);
+    }
+
+    let (resp, _redirect_chain) = send_request_following_redirects(
+        parsed,
+        reqwest::Method::GET,
+        headers,
+        options,
+        API_TIMEOUT,
+    )
+    .await?;
+
+    if !(200..300).contains(&resp.status) {
+        return Err(FetchError::FetcherError(format!(
+            "{} API error: HTTP {}",
+            api_name, resp.status
+        )));
+    }
+
+    let (body, _) = read_body_with_timeout(resp, BODY_TIMEOUT, max_body_size).await?;
+    Ok(body)
+}
+
 async fn fetch_pypi(
-    client: &reqwest::Client,
+    options: &FetchOptions,
     ua: &HeaderValue,
     name: &str,
     version: Option<&str>,
@@ -235,21 +261,7 @@ async fn fetch_pypi(
         None => format!("https://pypi.org/pypi/{}/json", name),
     };
 
-    let resp = client
-        .get(&api_url)
-        .header(USER_AGENT, ua.clone())
-        .send()
-        .await
-        .map_err(FetchError::from_reqwest)?;
-
-    if !resp.status().is_success() {
-        return Err(FetchError::FetcherError(format!(
-            "PyPI API error: HTTP {}",
-            resp.status()
-        )));
-    }
-
-    let (body, _) = read_body_with_timeout(resp, BODY_TIMEOUT, max_body_size).await?;
+    let body = registry_get(options, ua, None, &api_url, max_body_size, "PyPI").await?;
     let data: PyPIResponse = serde_json::from_slice(&body)
         .map_err(|e| FetchError::FetcherError(format!("Failed to parse PyPI data: {}", e)))?;
 
@@ -300,29 +312,22 @@ async fn fetch_pypi(
 }
 
 async fn fetch_crates_io(
-    client: &reqwest::Client,
+    options: &FetchOptions,
     ua: &HeaderValue,
     name: &str,
     max_body_size: usize,
 ) -> Result<String, FetchError> {
     let api_url = format!("https://crates.io/api/v1/crates/{}", name);
 
-    let resp = client
-        .get(&api_url)
-        .header(USER_AGENT, ua.clone())
-        .header(ACCEPT, HeaderValue::from_static("application/json"))
-        .send()
-        .await
-        .map_err(FetchError::from_reqwest)?;
-
-    if !resp.status().is_success() {
-        return Err(FetchError::FetcherError(format!(
-            "crates.io API error: HTTP {}",
-            resp.status()
-        )));
-    }
-
-    let (body, _) = read_body_with_timeout(resp, BODY_TIMEOUT, max_body_size).await?;
+    let body = registry_get(
+        options,
+        ua,
+        Some(HeaderValue::from_static("application/json")),
+        &api_url,
+        max_body_size,
+        "crates.io",
+    )
+    .await?;
     let data: CratesIoResponse = serde_json::from_slice(&body)
         .map_err(|e| FetchError::FetcherError(format!("Failed to parse crates.io data: {}", e)))?;
 
@@ -361,29 +366,22 @@ async fn fetch_crates_io(
 }
 
 async fn fetch_npm(
-    client: &reqwest::Client,
+    options: &FetchOptions,
     ua: &HeaderValue,
     name: &str,
     max_body_size: usize,
 ) -> Result<String, FetchError> {
     let api_url = format!("https://registry.npmjs.org/{}", name);
 
-    let resp = client
-        .get(&api_url)
-        .header(USER_AGENT, ua.clone())
-        .header(ACCEPT, HeaderValue::from_static("application/json"))
-        .send()
-        .await
-        .map_err(FetchError::from_reqwest)?;
-
-    if !resp.status().is_success() {
-        return Err(FetchError::FetcherError(format!(
-            "npm API error: HTTP {}",
-            resp.status()
-        )));
-    }
-
-    let (body, _) = read_body_with_timeout(resp, BODY_TIMEOUT, max_body_size).await?;
+    let body = registry_get(
+        options,
+        ua,
+        Some(HeaderValue::from_static("application/json")),
+        &api_url,
+        max_body_size,
+        "npm",
+    )
+    .await?;
     let data: NpmResponse = serde_json::from_slice(&body)
         .map_err(|e| FetchError::FetcherError(format!("Failed to parse npm data: {}", e)))?;
 

--- a/crates/fetchkit/src/fetchers/rss_feed.rs
+++ b/crates/fetchkit/src/fetchers/rss_feed.rs
@@ -6,8 +6,8 @@
 use crate::client::FetchOptions;
 use crate::error::FetchError;
 use crate::fetchers::default::{
-    apply_bot_auth_if_enabled, read_body_with_timeout, send_request_following_redirects,
-    BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE,
+    apply_bot_auth_if_enabled, header_value, read_body_with_timeout,
+    send_request_following_redirects, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE,
 };
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
@@ -112,9 +112,9 @@ impl Fetcher for RSSFeedFetcher {
         )
         .await?;
 
-        let status_code = response.status().as_u16();
-        let final_url = response.url().to_string();
-        if !response.status().is_success() {
+        let status_code = response.status;
+        let final_url = response.url.to_string();
+        if !(200..300).contains(&status_code) {
             return Ok(FetchResponse {
                 url: final_url,
                 status_code,
@@ -125,10 +125,7 @@ impl Fetcher for RSSFeedFetcher {
         }
 
         // Check content-type for feed detection (covers non-URL-pattern feeds)
-        let content_type = response
-            .headers()
-            .get(reqwest::header::CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
+        let content_type = header_value(&response.headers, reqwest::header::CONTENT_TYPE.as_str())
             .unwrap_or("")
             .to_string();
 

--- a/crates/fetchkit/src/fetchers/stackoverflow.rs
+++ b/crates/fetchkit/src/fetchers/stackoverflow.rs
@@ -5,11 +5,12 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
+use crate::fetchers::default::{read_full_body, transport_request};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use serde::Deserialize;
 use std::time::Duration;
 use url::Url;
@@ -126,32 +127,29 @@ impl Fetcher for StackOverflowFetcher {
         })?;
 
         let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-        let mut client_builder = reqwest::Client::builder()
-            .connect_timeout(API_TIMEOUT)
-            .timeout(API_TIMEOUT)
-            // THREAT[TM-SSRF-010]: no redirect following for API calls
-            .redirect(reqwest::redirect::Policy::none());
-
-        if !options.respect_proxy_env {
-            // THREAT[TM-NET-004]: Ignore ambient proxy env by default
-            client_builder = client_builder.no_proxy();
-        }
-
-        if options.dns_policy.block_private {
-            let validated_addr = options
-                .dns_policy
-                .resolve_and_validate(STACKEXCHANGE_API_HOST, STACKEXCHANGE_API_PORT)
-                .map_err(|_| FetchError::BlockedUrl)?;
-            // THREAT[TM-SSRF-005]: pin validated DNS answer for API host
-            client_builder = client_builder.resolve(STACKEXCHANGE_API_HOST, validated_addr);
-        }
-
-        let client = client_builder
-            .build()
-            .map_err(FetchError::ClientBuildError)?;
-
         let ua_header = HeaderValue::from_str(user_agent)
             .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
+
+        // THREAT[TM-SSRF-010]: single-hop transport request, redirects not followed.
+        // THREAT[TM-SSRF-005]: DNS pinned to the Stack Exchange API host per request.
+        let api_get = |url: String| {
+            let ua = ua_header.clone();
+            async move {
+                let parsed = Url::parse(&url).map_err(|_| FetchError::InvalidUrlScheme)?;
+                let mut headers = HeaderMap::new();
+                headers.insert(USER_AGENT, ua);
+                transport_request(
+                    parsed,
+                    reqwest::Method::GET,
+                    headers,
+                    options,
+                    API_TIMEOUT,
+                    STACKEXCHANGE_API_HOST,
+                    STACKEXCHANGE_API_PORT,
+                )
+                .await
+            }
+        };
 
         // Fetch question with markdown body
         let question_url = format!(
@@ -159,15 +157,10 @@ impl Fetcher for StackOverflowFetcher {
             question_id, site
         );
 
-        let q_response = client
-            .get(&question_url)
-            .header(USER_AGENT, ua_header.clone())
-            .send()
-            .await
-            .map_err(FetchError::from_reqwest)?;
+        let q_response = api_get(question_url).await?;
 
-        let status_code = q_response.status().as_u16();
-        if !q_response.status().is_success() {
+        let status_code = q_response.status;
+        if !(200..300).contains(&status_code) {
             let error_msg = if status_code == 404 {
                 format!("Question {} not found on {}", question_id, site)
             } else {
@@ -181,7 +174,8 @@ impl Fetcher for StackOverflowFetcher {
             });
         }
 
-        let q_data: ApiResponse<Question> = q_response.json().await.map_err(|e| {
+        let q_body = read_full_body(q_response, options).await?;
+        let q_data: ApiResponse<Question> = serde_json::from_slice(&q_body).map_err(|e| {
             FetchError::FetcherError(format!("Failed to parse question data: {}", e))
         })?;
 
@@ -196,17 +190,15 @@ impl Fetcher for StackOverflowFetcher {
                 question_id, site, MAX_ANSWERS
             );
 
-            match client
-                .get(&answers_url)
-                .header(USER_AGENT, ua_header)
-                .send()
-                .await
-            {
-                Ok(resp) if resp.status().is_success() => resp
-                    .json::<ApiResponse<Answer>>()
-                    .await
-                    .ok()
-                    .map(|r| r.items),
+            match api_get(answers_url).await {
+                Ok(resp) if (200..300).contains(&resp.status) => {
+                    match read_full_body(resp, options).await {
+                        Ok(body) => serde_json::from_slice::<ApiResponse<Answer>>(&body)
+                            .ok()
+                            .map(|r| r.items),
+                        Err(_) => None,
+                    }
+                }
                 _ => None,
             }
         } else {

--- a/crates/fetchkit/src/fetchers/twitter.rs
+++ b/crates/fetchkit/src/fetchers/twitter.rs
@@ -9,12 +9,14 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
-use crate::fetchers::default::{read_body_with_timeout, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE};
+use crate::fetchers::default::{
+    read_body_with_timeout, transport_request, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE,
+};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use serde::Deserialize;
 use std::time::Duration;
 use url::Url;
@@ -409,41 +411,17 @@ fn strip_html_tags(html: &str) -> String {
     result
 }
 
-fn build_client(
-    options: &FetchOptions,
-    host: &str,
-    port: u16,
-) -> Result<reqwest::Client, FetchError> {
+/// Build the common request headers (User-Agent + JSON Accept) for Twitter API calls.
+fn twitter_headers(options: &FetchOptions) -> HeaderMap {
     let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-    let mut builder = reqwest::Client::builder()
-        .connect_timeout(API_TIMEOUT)
-        .timeout(API_TIMEOUT)
-        .redirect(reqwest::redirect::Policy::none());
-
-    if !options.respect_proxy_env {
-        builder = builder.no_proxy();
-    }
-
-    if options.dns_policy.block_private {
-        let validated_addr = options
-            .dns_policy
-            .resolve_and_validate(host, port)
-            .map_err(|_| FetchError::BlockedUrl)?;
-        builder = builder.resolve(host, validated_addr);
-    }
-
-    builder
-        .default_headers({
-            let mut headers = reqwest::header::HeaderMap::new();
-            headers.insert(
-                USER_AGENT,
-                HeaderValue::from_str(user_agent)
-                    .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT)),
-            );
-            headers
-        })
-        .build()
-        .map_err(FetchError::ClientBuildError)
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_str(user_agent)
+            .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT)),
+    );
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+    headers
 }
 
 #[async_trait]
@@ -521,19 +499,23 @@ impl TwitterFetcher {
         tweet_id: &str,
         options: &FetchOptions,
     ) -> Result<SyndicationTweet, FetchError> {
-        let client = build_client(options, "cdn.syndication.twimg.com", 443)?;
-
         let syndication_url = format!("{}?id={}&token=0", SYNDICATION_BASE, tweet_id);
+        let parsed = Url::parse(&syndication_url).map_err(|_| FetchError::InvalidUrlScheme)?;
 
-        let response = client
-            .get(&syndication_url)
-            .header(ACCEPT, HeaderValue::from_static("application/json"))
-            .send()
-            .await
-            .map_err(FetchError::from_reqwest)?;
+        // THREAT[TM-SSRF-010]: single-hop request, redirects not followed.
+        let response = transport_request(
+            parsed,
+            reqwest::Method::GET,
+            twitter_headers(options),
+            options,
+            API_TIMEOUT,
+            "cdn.syndication.twimg.com",
+            443,
+        )
+        .await?;
 
-        let status = response.status().as_u16();
-        if !response.status().is_success() {
+        let status = response.status;
+        if !(200..300).contains(&status) {
             return Err(FetchError::FetcherError(format!(
                 "Syndication API returned HTTP {}",
                 status
@@ -563,19 +545,23 @@ impl TwitterFetcher {
         tweet_url: &str,
         options: &FetchOptions,
     ) -> Result<OEmbedResponse, FetchError> {
-        let client = build_client(options, "publish.x.com", 443)?;
-
         let oembed_url = format!("{}?url={}", OEMBED_BASE, tweet_url);
+        let parsed = Url::parse(&oembed_url).map_err(|_| FetchError::InvalidUrlScheme)?;
 
-        let response = client
-            .get(&oembed_url)
-            .header(ACCEPT, HeaderValue::from_static("application/json"))
-            .send()
-            .await
-            .map_err(FetchError::from_reqwest)?;
+        // THREAT[TM-SSRF-010]: single-hop request, redirects not followed.
+        let response = transport_request(
+            parsed,
+            reqwest::Method::GET,
+            twitter_headers(options),
+            options,
+            API_TIMEOUT,
+            "publish.x.com",
+            443,
+        )
+        .await?;
 
-        let status = response.status().as_u16();
-        if !response.status().is_success() {
+        let status = response.status;
+        if !(200..300).contains(&status) {
             return Err(FetchError::FetcherError(format!(
                 "oEmbed API returned HTTP {}",
                 status

--- a/crates/fetchkit/src/fetchers/wikipedia.rs
+++ b/crates/fetchkit/src/fetchers/wikipedia.rs
@@ -6,13 +6,14 @@
 use crate::client::FetchOptions;
 use crate::error::FetchError;
 use crate::fetchers::default::{
-    read_body_with_timeout, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE, TRUNCATION_MESSAGE,
+    read_body_with_timeout, send_request_following_redirects, BODY_TIMEOUT, DEFAULT_MAX_BODY_SIZE,
+    TRUNCATION_MESSAGE,
 };
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use serde::Deserialize;
 use std::time::Duration;
 use url::Url;
@@ -112,19 +113,6 @@ impl Fetcher for WikipediaFetcher {
             .ok_or_else(|| FetchError::FetcherError("Not a valid Wikipedia URL".to_string()))?;
 
         let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-        let mut client_builder = reqwest::Client::builder()
-            .connect_timeout(API_TIMEOUT)
-            .timeout(API_TIMEOUT)
-            .redirect(reqwest::redirect::Policy::limited(3));
-
-        if !options.respect_proxy_env {
-            client_builder = client_builder.no_proxy();
-        }
-
-        let client = client_builder
-            .build()
-            .map_err(FetchError::ClientBuildError)?;
-
         let ua_header = HeaderValue::from_str(user_agent)
             .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
 
@@ -133,17 +121,24 @@ impl Fetcher for WikipediaFetcher {
             "https://{}.wikipedia.org/api/rest_v1/page/summary/{}",
             lang, title
         );
+        let parsed_summary = Url::parse(&summary_url).map_err(|_| FetchError::InvalidUrlScheme)?;
 
-        let summary_resp = client
-            .get(&summary_url)
-            .header(USER_AGENT, ua_header.clone())
-            .header(ACCEPT, HeaderValue::from_static("application/json"))
-            .send()
-            .await
-            .map_err(FetchError::from_reqwest)?;
+        let mut summary_headers = HeaderMap::new();
+        summary_headers.insert(USER_AGENT, ua_header.clone());
+        summary_headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
-        let status_code = summary_resp.status().as_u16();
-        if !summary_resp.status().is_success() {
+        // THREAT[TM-SSRF-010]: manual redirect following re-validates each hop.
+        let (summary_resp, _) = send_request_following_redirects(
+            parsed_summary,
+            reqwest::Method::GET,
+            summary_headers,
+            options,
+            API_TIMEOUT,
+        )
+        .await?;
+
+        let status_code = summary_resp.status;
+        if !(200..300).contains(&status_code) {
             let error_msg = if status_code == 404 {
                 format!("Article '{}' not found on {}.wikipedia.org", title, lang)
             } else {
@@ -170,23 +165,33 @@ impl Fetcher for WikipediaFetcher {
             lang, title
         );
 
-        let full_content = match client
-            .get(&html_url)
-            .header(USER_AGENT, ua_header)
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => {
-                let (html_body, truncated) =
-                    read_body_with_timeout(resp, BODY_TIMEOUT, max_body_size).await?;
-                let html = String::from_utf8_lossy(&html_body);
-                let mut markdown = crate::convert::html_to_markdown(&html);
-                if truncated {
-                    markdown.push_str(TRUNCATION_MESSAGE);
+        let full_content = match Url::parse(&html_url) {
+            Ok(parsed_html) => {
+                let mut html_headers = HeaderMap::new();
+                html_headers.insert(USER_AGENT, ua_header);
+                match send_request_following_redirects(
+                    parsed_html,
+                    reqwest::Method::GET,
+                    html_headers,
+                    options,
+                    API_TIMEOUT,
+                )
+                .await
+                {
+                    Ok((resp, _)) if (200..300).contains(&resp.status) => {
+                        let (html_body, truncated) =
+                            read_body_with_timeout(resp, BODY_TIMEOUT, max_body_size).await?;
+                        let html = String::from_utf8_lossy(&html_body);
+                        let mut markdown = crate::convert::html_to_markdown(&html);
+                        if truncated {
+                            markdown.push_str(TRUNCATION_MESSAGE);
+                        }
+                        Some(markdown)
+                    }
+                    _ => None,
                 }
-                Some(markdown)
             }
-            _ => None,
+            Err(_) => None,
         };
 
         let content = format_wikipedia_response(&summary, full_content.as_deref(), &lang);

--- a/crates/fetchkit/src/fetchers/youtube.rs
+++ b/crates/fetchkit/src/fetchers/youtube.rs
@@ -5,17 +5,22 @@
 
 use crate::client::FetchOptions;
 use crate::error::FetchError;
+use crate::fetchers::default::{read_full_body, transport_request};
 use crate::fetchers::Fetcher;
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
-use reqwest::header::{HeaderValue, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use serde::Deserialize;
 use std::time::Duration;
 use url::Url;
 
 const API_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_TRANSCRIPT_CHARS: usize = 15_000;
+
+/// YouTube host and port (DNS-pinned per request).
+const YOUTUBE_HOST: &str = "www.youtube.com";
+const YOUTUBE_PORT: u16 = 443;
 
 /// YouTube video fetcher
 ///
@@ -99,19 +104,6 @@ impl Fetcher for YouTubeFetcher {
             .ok_or_else(|| FetchError::FetcherError("Not a valid YouTube URL".to_string()))?;
 
         let user_agent = options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
-        let mut client_builder = reqwest::Client::builder()
-            .connect_timeout(API_TIMEOUT)
-            .timeout(API_TIMEOUT)
-            .redirect(reqwest::redirect::Policy::none());
-
-        if !options.respect_proxy_env {
-            client_builder = client_builder.no_proxy();
-        }
-
-        let client = client_builder
-            .build()
-            .map_err(FetchError::ClientBuildError)?;
-
         let ua_header = HeaderValue::from_str(user_agent)
             .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
 
@@ -126,13 +118,27 @@ impl Fetcher for YouTubeFetcher {
             .append_pair("url", &canonical_url)
             .append_pair("format", "json");
 
-        let oembed = match client
-            .get(oembed_url.as_str())
-            .header(USER_AGENT, ua_header.clone())
-            .send()
-            .await
+        let mut oembed_headers = HeaderMap::new();
+        oembed_headers.insert(USER_AGENT, ua_header.clone());
+
+        // THREAT[TM-SSRF-010]: single-hop request, redirects not followed.
+        let oembed = match transport_request(
+            oembed_url,
+            reqwest::Method::GET,
+            oembed_headers,
+            options,
+            API_TIMEOUT,
+            YOUTUBE_HOST,
+            YOUTUBE_PORT,
+        )
+        .await
         {
-            Ok(resp) if resp.status().is_success() => resp.json::<OEmbedResponse>().await.ok(),
+            Ok(resp) if (200..300).contains(&resp.status) => {
+                match read_full_body(resp, options).await {
+                    Ok(body) => serde_json::from_slice::<OEmbedResponse>(&body).ok(),
+                    Err(_) => None,
+                }
+            }
             _ => None,
         };
 
@@ -145,7 +151,7 @@ impl Fetcher for YouTubeFetcher {
         let author_url = oembed.as_ref().and_then(|o| o.author_url.clone());
 
         // Attempt transcript extraction via timedtext API
-        let transcript = fetch_transcript(&client, &ua_header, &video_id, options).await;
+        let transcript = fetch_transcript(&ua_header, &video_id, options).await;
 
         let content = format_youtube_response(
             &title,
@@ -170,7 +176,6 @@ impl Fetcher for YouTubeFetcher {
 /// Attempt to fetch transcript/captions via YouTube's timedtext XML API.
 /// Returns None if transcript is unavailable.
 async fn fetch_transcript(
-    client: &reqwest::Client,
     ua: &HeaderValue,
     video_id: &str,
     options: &FetchOptions,
@@ -184,18 +189,28 @@ async fn fetch_transcript(
     let timedtext_url = Url::parse(&timedtext_url).ok()?;
     options.validate_url(&timedtext_url).ok()?;
 
-    let resp = client
-        .get(timedtext_url.as_str())
-        .header(USER_AGENT, ua.clone())
-        .send()
-        .await
-        .ok()?;
+    let mut headers = HeaderMap::new();
+    headers.insert(USER_AGENT, ua.clone());
 
-    if !resp.status().is_success() {
+    // THREAT[TM-SSRF-010]: single-hop request, redirects not followed.
+    let resp = transport_request(
+        timedtext_url,
+        reqwest::Method::GET,
+        headers,
+        options,
+        API_TIMEOUT,
+        YOUTUBE_HOST,
+        YOUTUBE_PORT,
+    )
+    .await
+    .ok()?;
+
+    if !(200..300).contains(&resp.status) {
         return None;
     }
 
-    let xml = resp.text().await.ok()?;
+    let body = read_full_body(resp, options).await.ok()?;
+    let xml = String::from_utf8_lossy(&body).into_owned();
     if let Some(max_body_size) = options.max_body_size {
         if xml.len() > max_body_size {
             return None;

--- a/crates/fetchkit/src/lib.rs
+++ b/crates/fetchkit/src/lib.rs
@@ -82,6 +82,7 @@ mod error;
 pub mod fetchers;
 pub mod file_saver;
 mod tool;
+pub mod transport;
 mod types;
 
 pub use client::{batch_fetch, batch_fetch_with_options, fetch, fetch_with_options, FetchOptions};
@@ -99,6 +100,10 @@ pub use file_saver::{FileSaveError, FileSaver, LocalFileSaver, SaveResult};
 pub use tool::{
     Tool, ToolBuilder, ToolExecution, ToolImage, ToolOutput, ToolOutputMetadata, ToolService,
     ToolStatus,
+};
+pub use transport::{
+    BodyStream, HttpTransport, ReqwestTransport, TransportError, TransportMethod, TransportRequest,
+    TransportResponse,
 };
 pub use types::{FetchRequest, FetchResponse, HttpMethod, PageLink, PageMetadata};
 

--- a/crates/fetchkit/src/tool.rs
+++ b/crates/fetchkit/src/tool.rs
@@ -10,10 +10,12 @@ use crate::dns::DnsPolicy;
 use crate::error::{FetchError, ToolError};
 use crate::fetchers::FetcherRegistry;
 use crate::file_saver::FileSaver;
+use crate::transport::HttpTransport;
 use crate::types::{FetchRequest, FetchResponse};
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
 use tower::Service;
@@ -115,7 +117,7 @@ pub struct ToolOutput {
 ///
 /// assert_eq!(tool.name(), "web_fetch");
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct ToolBuilder {
     locale: String,
     /// Enable as_markdown option
@@ -145,6 +147,40 @@ pub struct ToolBuilder {
     /// Web Bot Authentication config.
     #[cfg(feature = "bot-auth")]
     bot_auth: Option<BotAuthConfig>,
+    /// Pluggable HTTP transport. None => default ReqwestTransport.
+    transport: Option<Arc<dyn HttpTransport>>,
+}
+
+// Manual Debug: `transport` is a trait object that does not implement Debug
+// (same pattern as FetchOptions).
+impl std::fmt::Debug for ToolBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("ToolBuilder");
+        d.field("locale", &self.locale)
+            .field("enable_markdown", &self.enable_markdown)
+            .field("enable_text", &self.enable_text)
+            .field("user_agent", &self.user_agent)
+            .field("allow_prefixes", &self.allow_prefixes)
+            .field("block_prefixes", &self.block_prefixes)
+            .field("dns_policy", &self.dns_policy)
+            .field("max_body_size", &self.max_body_size)
+            .field("enable_save_to_file", &self.enable_save_to_file)
+            .field("respect_proxy_env", &self.respect_proxy_env)
+            .field("allowed_ports", &self.allowed_ports)
+            .field("blocked_hosts", &self.blocked_hosts)
+            .field("same_host_redirects_only", &self.same_host_redirects_only);
+        #[cfg(feature = "bot-auth")]
+        d.field("bot_auth", &self.bot_auth);
+        d.field(
+            "transport",
+            &self
+                .transport
+                .as_ref()
+                .map(|_| "<custom>")
+                .unwrap_or("None"),
+        );
+        d.finish()
+    }
 }
 
 impl ToolBuilder {
@@ -295,6 +331,19 @@ impl ToolBuilder {
         self
     }
 
+    /// Set a custom HTTP transport for all tool execution paths.
+    ///
+    /// A host application can supply its own [`HttpTransport`] to route fetchkit's
+    /// outbound HTTP through a dedicated egress boundary while keeping the Tool
+    /// surface (description, schemas, llmtxt, `execute`, `execute_with_saver`).
+    /// fetchkit still performs URL validation, DNS policy resolution, redirect
+    /// following, bot-auth signing, and body/timeout caps; only the socket-level
+    /// send is delegated. Default: the built-in `ReqwestTransport`.
+    pub fn transport(mut self, transport: Arc<dyn HttpTransport>) -> Self {
+        self.transport = Some(transport);
+        self
+    }
+
     /// Apply a production-oriented hardening profile.
     ///
     /// This preset keeps private IP blocking enabled, ignores ambient proxy
@@ -336,6 +385,7 @@ impl ToolBuilder {
             same_host_redirects_only: self.same_host_redirects_only,
             #[cfg(feature = "bot-auth")]
             bot_auth: self.bot_auth.clone(),
+            transport: self.transport.clone(),
         }
     }
 
@@ -381,7 +431,7 @@ impl ToolBuilder {
 ///
 /// Created via [`ToolBuilder`]. Provides methods for executing fetch requests,
 /// retrieving schemas, and accessing tool metadata.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Tool {
     locale: String,
     display_name: String,
@@ -401,6 +451,42 @@ pub struct Tool {
     same_host_redirects_only: bool,
     #[cfg(feature = "bot-auth")]
     bot_auth: Option<BotAuthConfig>,
+    transport: Option<Arc<dyn HttpTransport>>,
+}
+
+// Manual Debug: `transport` is a trait object that does not implement Debug
+// (same pattern as FetchOptions).
+impl std::fmt::Debug for Tool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("Tool");
+        d.field("locale", &self.locale)
+            .field("display_name", &self.display_name)
+            .field("description", &self.description)
+            .field("version", &self.version)
+            .field("enable_markdown", &self.enable_markdown)
+            .field("enable_text", &self.enable_text)
+            .field("user_agent", &self.user_agent)
+            .field("allow_prefixes", &self.allow_prefixes)
+            .field("block_prefixes", &self.block_prefixes)
+            .field("dns_policy", &self.dns_policy)
+            .field("max_body_size", &self.max_body_size)
+            .field("enable_save_to_file", &self.enable_save_to_file)
+            .field("respect_proxy_env", &self.respect_proxy_env)
+            .field("allowed_ports", &self.allowed_ports)
+            .field("blocked_hosts", &self.blocked_hosts)
+            .field("same_host_redirects_only", &self.same_host_redirects_only);
+        #[cfg(feature = "bot-auth")]
+        d.field("bot_auth", &self.bot_auth);
+        d.field(
+            "transport",
+            &self
+                .transport
+                .as_ref()
+                .map(|_| "<custom>")
+                .unwrap_or("None"),
+        );
+        d.finish()
+    }
 }
 
 impl Default for Tool {
@@ -563,6 +649,9 @@ impl Tool {
             same_host_redirects_only: self.same_host_redirects_only,
             #[cfg(feature = "bot-auth")]
             bot_auth: self.bot_auth.clone(),
+            // None => default ReqwestTransport; hosts inject a custom transport via
+            // ToolBuilder::transport and every Tool execution path honors it.
+            transport: self.transport.clone(),
         }
     }
 }

--- a/crates/fetchkit/src/transport.rs
+++ b/crates/fetchkit/src/transport.rs
@@ -1,0 +1,250 @@
+// Decisions:
+// - Transport is a single-hop socket adapter. It NEVER follows redirects and NEVER
+//   resolves DNS for policy: fetchkit owns redirect following (manual, per-hop validated)
+//   and DNS policy (resolve-then-check). The transport only opens the connection and
+//   streams bytes back. This keeps all security policy (TM-SSRF, TM-NET, TM-DOS) inside
+//   fetchkit so a host application (e.g. Everruns) can swap the final socket transport
+//   without being able to bypass fetchkit's safeguards.
+// - pinned_addrs are produced by fetchkit's DnsPolicy (resolve-then-check). A custom
+//   transport MUST connect only to those addresses when the list is non-empty
+//   (TM-SSRF-001/005: prevents DNS rebinding). ReqwestTransport enforces this via
+//   `reqwest::ClientBuilder::resolve()`.
+// - The body is a boxed async byte stream so DefaultFetcher's body-size caps,
+//   body timeout, and partial-content-on-timeout keep working mid-stream (TM-DOS-001/003).
+//! Pluggable HTTP transport abstraction.
+//!
+//! [`HttpTransport`] lets a host application route fetchkit's outbound HTTP through
+//! its own egress boundary while fetchkit retains all content logic and security
+//! policy. fetchkit becomes a request/response adapter rather than owning the final
+//! network transport.
+//!
+//! The default implementation, [`ReqwestTransport`], preserves the historical
+//! behavior exactly: a fresh `reqwest::Client` per request, redirects disabled,
+//! proxy env ignored unless opted in, and DNS pinned to fetchkit-validated addresses.
+
+use crate::error::FetchError;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::{Stream, StreamExt};
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::time::Duration;
+use url::Url;
+
+/// HTTP method for a transport request. Mirrors the GET/HEAD-only contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportMethod {
+    /// HTTP GET
+    Get,
+    /// HTTP HEAD
+    Head,
+}
+
+/// A single outbound HTTP request handed to an [`HttpTransport`].
+///
+/// This represents exactly one hop. fetchkit performs URL validation, DNS policy
+/// resolution, and manual redirect following itself; the transport only executes
+/// the request as specified here.
+pub struct TransportRequest {
+    /// Request method (GET or HEAD).
+    pub method: TransportMethod,
+    /// Fully-resolved request URL for this hop.
+    pub url: Url,
+    /// Request headers (already includes User-Agent, Accept, conditional headers,
+    /// and any bot-auth signature headers — signing stays in fetchkit).
+    pub headers: Vec<(String, String)>,
+    /// Connect + first-byte / overall timeout for this hop, if any.
+    pub timeout: Option<Duration>,
+    /// Pre-resolved, policy-validated socket addresses for the request host.
+    ///
+    /// Produced by fetchkit's [`DnsPolicy`](crate::DnsPolicy) (resolve-then-check).
+    /// When non-empty a transport MUST connect only to these addresses — this is the
+    /// SSRF / DNS-rebinding protection (TM-SSRF-001, TM-SSRF-005). When empty, the
+    /// policy permits ambient resolution (e.g. `DnsPolicy::allow_all`).
+    pub pinned_addrs: Vec<SocketAddr>,
+    /// Whether ambient `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` should be honored.
+    ///
+    /// Carried per-request because it is derived from `FetchOptions`. Defaults to
+    /// `false` (proxy env ignored) per TM-NET-004.
+    pub respect_proxy_env: bool,
+}
+
+/// Boxed async byte stream for a streaming response body.
+pub type BodyStream = Pin<Box<dyn Stream<Item = Result<Bytes, TransportError>> + Send>>;
+
+/// A response produced by an [`HttpTransport`].
+///
+/// The body is a streaming byte source so fetchkit can apply its body-size cap,
+/// body timeout, and partial-content-on-timeout logic while reading.
+pub struct TransportResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Final URL after the transport executed the request (same as request URL;
+    /// fetchkit follows redirects itself, so this normally equals the request URL).
+    pub url: Url,
+    /// Response headers.
+    pub headers: Vec<(String, String)>,
+    /// Streaming response body.
+    pub body: BodyStream,
+}
+
+/// Errors a transport can return. Variants map onto [`FetchError`] without leaking
+/// internal hostnames/IPs (TM-LEAK-001).
+///
+/// Custom transports use the generic [`Connect`](TransportError::Connect),
+/// [`Timeout`](TransportError::Timeout), [`Request`](TransportError::Request), and
+/// [`Other`](TransportError::Other) variants. The [`Reqwest`](TransportError::Reqwest)
+/// variant lets the default [`ReqwestTransport`] preserve reqwest's precise error
+/// classification (so historical [`FetchError`] mapping is unchanged); custom
+/// transports never need it.
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    /// Failed to establish a connection (DNS/connect/TLS).
+    #[error("transport connect error")]
+    Connect,
+    /// Timed out waiting for the server.
+    #[error("transport timeout")]
+    Timeout,
+    /// Error issuing the request or reading the response.
+    #[error("transport request error: {0}")]
+    Request(String),
+    /// Any other transport failure.
+    #[error("transport error: {0}")]
+    Other(String),
+    /// A raw reqwest error from the default transport (preserves precise classification).
+    #[error("transport reqwest error")]
+    Reqwest(#[source] reqwest::Error),
+}
+
+impl From<TransportError> for FetchError {
+    fn from(err: TransportError) -> Self {
+        // THREAT[TM-LEAK-001]: keep generic messages; do not surface resolved IPs/hosts.
+        match err {
+            // Reqwest errors keep the historical classification (connect/timeout/body/...).
+            TransportError::Reqwest(e) => FetchError::from_reqwest(e),
+            TransportError::Connect => {
+                FetchError::RequestError("failed to connect to server".to_string())
+            }
+            TransportError::Timeout => FetchError::FirstByteTimeout,
+            TransportError::Request(msg) => FetchError::RequestError(msg),
+            TransportError::Other(msg) => FetchError::RequestError(msg),
+        }
+    }
+}
+
+/// A pluggable HTTP transport.
+///
+/// Implementors execute a single [`TransportRequest`] and return a streaming
+/// [`TransportResponse`]. fetchkit retains all URL validation, DNS policy, redirect
+/// following, and content handling; only the socket-level send moves here.
+#[async_trait]
+pub trait HttpTransport: Send + Sync {
+    /// Execute a single HTTP request hop.
+    async fn execute(&self, req: TransportRequest) -> Result<TransportResponse, TransportError>;
+}
+
+/// Default transport backed by `reqwest`.
+///
+/// Preserves the historical fetch behavior exactly:
+/// - new `reqwest::Client` per request (TM-NET-003: no pool state leakage)
+/// - redirects disabled (TM-SSRF-010: fetchkit follows redirects manually)
+/// - ambient proxy env ignored unless `respect_proxy_env` (TM-NET-004)
+/// - DNS pinned to fetchkit-validated addresses when `pinned_addrs` is non-empty
+///   (TM-SSRF-001, TM-SSRF-005)
+#[derive(Debug, Default, Clone)]
+pub struct ReqwestTransport;
+
+impl ReqwestTransport {
+    /// Create a new default reqwest-backed transport.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl HttpTransport for ReqwestTransport {
+    async fn execute(&self, req: TransportRequest) -> Result<TransportResponse, TransportError> {
+        // THREAT[TM-NET-003]: New client per request prevents connection-pool state leakage.
+        let mut builder = reqwest::Client::builder().redirect(reqwest::redirect::Policy::none());
+
+        if let Some(timeout) = req.timeout {
+            builder = builder.connect_timeout(timeout).timeout(timeout);
+        }
+
+        if !req.respect_proxy_env {
+            // THREAT[TM-NET-004]: Ignore ambient proxy env by default in shared runtimes.
+            builder = builder.no_proxy();
+        }
+
+        // THREAT[TM-SSRF-001]: Pin connection to fetchkit's validated addresses.
+        // THREAT[TM-SSRF-005]: Prevents reqwest from re-resolving (DNS rebinding).
+        if !req.pinned_addrs.is_empty() {
+            if let Some(host) = req.url.host_str() {
+                builder = builder.resolve_to_addrs(host, &req.pinned_addrs);
+            }
+        }
+
+        let client = builder
+            .build()
+            .map_err(|e| TransportError::Other(e.to_string()))?;
+
+        let method = match req.method {
+            TransportMethod::Get => reqwest::Method::GET,
+            TransportMethod::Head => reqwest::Method::HEAD,
+        };
+
+        let mut request = client.request(method, req.url.clone());
+        for (name, value) in &req.headers {
+            request = request.header(name, value);
+        }
+
+        let response = request.send().await.map_err(TransportError::Reqwest)?;
+
+        let status = response.status().as_u16();
+        let final_url = response.url().clone();
+        let headers = response
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|v| (name.as_str().to_string(), v.to_string()))
+            })
+            .collect();
+
+        let body: BodyStream = Box::pin(
+            response
+                .bytes_stream()
+                .map(|chunk| chunk.map_err(TransportError::Reqwest)),
+        );
+
+        Ok(TransportResponse {
+            status,
+            url: final_url,
+            headers,
+            body,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transport_error_maps_to_fetch_error() {
+        assert!(matches!(
+            FetchError::from(TransportError::Timeout),
+            FetchError::FirstByteTimeout
+        ));
+        assert!(matches!(
+            FetchError::from(TransportError::Connect),
+            FetchError::RequestError(_)
+        ));
+        assert!(matches!(
+            FetchError::from(TransportError::Request("x".into())),
+            FetchError::RequestError(_)
+        ));
+    }
+}

--- a/crates/fetchkit/tests/transport.rs
+++ b/crates/fetchkit/tests/transport.rs
@@ -1,0 +1,331 @@
+//! Integration tests for the pluggable HTTP transport.
+//!
+//! A custom in-memory transport proves fetchers route HTTP through the injected
+//! transport and never touch the network, that pinned addrs flow from DNS policy,
+//! and that DefaultFetcher's streaming caps still apply to a custom transport body.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use fetchkit::{
+    DnsPolicy, FetchOptions, FetchRequest, Fetcher, HttpMethod, HttpTransport, TransportError,
+    TransportMethod, TransportRequest, TransportResponse,
+};
+use std::sync::{Arc, Mutex};
+
+/// One canned response keyed by URL substring.
+#[derive(Clone)]
+struct Canned {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+/// In-memory transport. Records every request and replies with canned responses.
+/// Connecting to the network would be a bug — this never does.
+struct MockTransport {
+    /// (url, method, pinned_addrs) recorded per call.
+    calls: Mutex<Vec<(String, TransportMethod, Vec<std::net::SocketAddr>)>>,
+    /// match-by-substring => response.
+    routes: Vec<(String, Canned)>,
+}
+
+impl MockTransport {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            routes: Vec::new(),
+        }
+    }
+
+    fn route(mut self, contains: &str, status: u16, ct: &str, body: &[u8]) -> Self {
+        self.routes.push((
+            contains.to_string(),
+            Canned {
+                status,
+                headers: vec![("content-type".to_string(), ct.to_string())],
+                body: body.to_vec(),
+            },
+        ));
+        self
+    }
+
+    fn calls(&self) -> Vec<(String, TransportMethod, Vec<std::net::SocketAddr>)> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl HttpTransport for MockTransport {
+    async fn execute(&self, req: TransportRequest) -> Result<TransportResponse, TransportError> {
+        self.calls.lock().unwrap().push((
+            req.url.to_string(),
+            req.method,
+            req.pinned_addrs.clone(),
+        ));
+
+        let canned = self
+            .routes
+            .iter()
+            .find(|(needle, _)| req.url.as_str().contains(needle.as_str()))
+            .map(|(_, c)| c.clone())
+            .unwrap_or(Canned {
+                status: 404,
+                headers: vec![("content-type".to_string(), "text/plain".to_string())],
+                body: b"not found".to_vec(),
+            });
+
+        let body_bytes = Bytes::from(canned.body);
+        let stream = futures::stream::once(async move { Ok(body_bytes) });
+
+        Ok(TransportResponse {
+            status: canned.status,
+            url: req.url,
+            headers: canned.headers,
+            body: Box::pin(stream),
+        })
+    }
+}
+
+fn options_with(transport: Arc<dyn HttpTransport>) -> FetchOptions {
+    FetchOptions {
+        enable_markdown: true,
+        enable_text: true,
+        // allow_all => no DNS resolution; pinned_addrs stays empty so the mock host
+        // does not need to resolve.
+        dns_policy: DnsPolicy::allow_all(),
+        transport: Some(transport),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn default_fetcher_get_uses_injected_transport() {
+    let mock = Arc::new(MockTransport::new().route(
+        "example.test/page",
+        200,
+        "text/plain",
+        b"hello via transport",
+    ));
+    let options = options_with(mock.clone());
+
+    let fetcher = fetchkit::DefaultFetcher::new();
+    let request = FetchRequest::new("https://example.test/page");
+    let response = fetcher.fetch(&request, &options).await.unwrap();
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.content.as_deref(), Some("hello via transport"));
+
+    let calls = mock.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].1, TransportMethod::Get);
+    assert!(calls[0].0.contains("example.test/page"));
+}
+
+#[tokio::test]
+async fn default_fetcher_head_uses_injected_transport() {
+    let mock = Arc::new(MockTransport::new().route("example.test/head", 200, "text/html", b""));
+    let options = options_with(mock.clone());
+
+    let fetcher = fetchkit::DefaultFetcher::new();
+    let request = FetchRequest::new("https://example.test/head").method(HttpMethod::Head);
+    let response = fetcher.fetch(&request, &options).await.unwrap();
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.method.as_deref(), Some("HEAD"));
+    assert!(response.content.is_none());
+
+    let calls = mock.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].1, TransportMethod::Head);
+}
+
+#[tokio::test]
+async fn default_fetcher_follows_redirect_through_transport_with_per_hop_validation() {
+    // First hop redirects; transport returns a 302 with Location. fetchkit must follow
+    // it (per-hop) through the transport and land on the final response.
+    // The shared `route` helper only sets content-type, so use a bespoke transport that
+    // can emit a Location header.
+    struct RedirectTransport {
+        calls: Mutex<Vec<String>>,
+    }
+    #[async_trait]
+    impl HttpTransport for RedirectTransport {
+        async fn execute(
+            &self,
+            req: TransportRequest,
+        ) -> Result<TransportResponse, TransportError> {
+            self.calls.lock().unwrap().push(req.url.to_string());
+            if req.url.path() == "/start" {
+                return Ok(TransportResponse {
+                    status: 302,
+                    url: req.url.clone(),
+                    headers: vec![(
+                        "location".to_string(),
+                        "https://example.test/final".to_string(),
+                    )],
+                    body: Box::pin(futures::stream::once(async { Ok(Bytes::new()) })),
+                });
+            }
+            Ok(TransportResponse {
+                status: 200,
+                url: req.url,
+                headers: vec![("content-type".to_string(), "text/plain".to_string())],
+                body: Box::pin(futures::stream::once(async {
+                    Ok(Bytes::from_static(b"arrived"))
+                })),
+            })
+        }
+    }
+    let redirect = Arc::new(RedirectTransport {
+        calls: Mutex::new(Vec::new()),
+    });
+    let options = options_with(redirect.clone());
+
+    let fetcher = fetchkit::DefaultFetcher::new();
+    let request = FetchRequest::new("https://example.test/start");
+    let response = fetcher.fetch(&request, &options).await.unwrap();
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.content.as_deref(), Some("arrived"));
+    assert_eq!(response.redirect_chain.len(), 1);
+
+    let calls = redirect.calls.lock().unwrap();
+    assert_eq!(calls.len(), 2, "should follow exactly one redirect hop");
+    assert!(calls[0].contains("/start"));
+    assert!(calls[1].contains("/final"));
+}
+
+#[tokio::test]
+async fn default_fetcher_enforces_body_cap_on_transport_stream() {
+    // Body cap must apply to the transport's streamed bytes.
+    let big = vec![b'a'; 50];
+    let mock = Arc::new(MockTransport::new().route("example.test/big", 200, "text/plain", &big));
+    let mut options = options_with(mock.clone());
+    options.max_body_size = Some(10);
+
+    let fetcher = fetchkit::DefaultFetcher::new();
+    let request = FetchRequest::new("https://example.test/big");
+    let response = fetcher.fetch(&request, &options).await.unwrap();
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.truncated, Some(true));
+    let content = response.content.unwrap();
+    // 10 captured bytes + truncation marker.
+    assert!(content.starts_with("aaaaaaaaaa"));
+    assert!(content.contains("content truncated"));
+    assert_eq!(response.size, Some(10));
+}
+
+#[tokio::test]
+async fn wikipedia_fetcher_uses_injected_transport() {
+    let summary = br#"{"title":"Rust","extract":"A language.","description":"PL"}"#;
+    let mock = Arc::new(
+        MockTransport::new()
+            .route("/page/summary/", 200, "application/json", summary)
+            .route("/page/html/", 200, "text/html", b"<p>Body</p>"),
+    );
+    let options = options_with(mock.clone());
+
+    let fetcher = fetchkit::WikipediaFetcher::new();
+    let request = FetchRequest::new("https://en.wikipedia.org/wiki/Rust");
+    let response = fetcher.fetch(&request, &options).await.unwrap();
+
+    assert_eq!(response.status_code, 200);
+    let content = response.content.unwrap();
+    assert!(content.contains("# Rust"));
+
+    // Both the summary and html API endpoints went through the mock transport — no network.
+    let calls = mock.calls();
+    assert!(calls.iter().any(|(u, _, _)| u.contains("/page/summary/")));
+    assert!(calls.iter().any(|(u, _, _)| u.contains("/page/html/")));
+}
+
+#[tokio::test]
+async fn tool_execute_uses_injected_transport() {
+    let mock = Arc::new(MockTransport::new().route(
+        "example.test/tool",
+        200,
+        "text/plain",
+        b"tool via transport",
+    ));
+
+    let tool = fetchkit::Tool::builder()
+        // allow_all => no DNS resolution, so the fake host never resolves.
+        .block_private_ips(false)
+        .transport(mock.clone())
+        .build();
+
+    // Manual Debug must render without exposing the trait object.
+    assert!(format!("{tool:?}").contains("transport: \"<custom>\""));
+
+    let response = tool
+        .execute(FetchRequest::new("https://example.test/tool"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.content.as_deref(), Some("tool via transport"));
+
+    // Exactly one HTTP exchange, all through the mock — no network.
+    let calls = mock.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].1, TransportMethod::Get);
+    assert!(calls[0].0.contains("example.test/tool"));
+}
+
+#[tokio::test]
+async fn tool_execute_with_saver_uses_injected_transport() {
+    let mock = Arc::new(MockTransport::new().route(
+        "example.test/file.bin",
+        200,
+        "application/octet-stream",
+        b"binary via transport",
+    ));
+
+    let tool = fetchkit::Tool::builder()
+        .block_private_ips(false)
+        .enable_save_to_file(true)
+        .transport(mock.clone())
+        .build();
+
+    let dir = tempfile::tempdir().unwrap();
+    let saver = fetchkit::LocalFileSaver::new(Some(dir.path().to_path_buf()));
+
+    let request = FetchRequest::new("https://example.test/file.bin").save_to_file("payload.bin");
+    let response = tool
+        .execute_with_saver(request, Some(&saver))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.bytes_written, Some(20));
+    let saved_path = response.saved_path.expect("saved_path must be set");
+    assert_eq!(std::fs::read(&saved_path).unwrap(), b"binary via transport");
+
+    let calls = mock.calls();
+    assert_eq!(calls.len(), 1);
+    assert!(calls[0].0.contains("example.test/file.bin"));
+}
+
+#[test]
+fn dns_policy_populates_pinned_addrs_for_resolved_host() {
+    // block_private resolves and validates, producing a pinned addr for a public host.
+    let policy = DnsPolicy::block_private_ips();
+    // 127.0.0.1 resolves to loopback and is blocked => no pinned addr (error).
+    assert!(policy.pinned_addrs("127.0.0.1", 80).is_err());
+
+    // A literal public IP resolves to itself and is allowed => exactly one pinned addr.
+    let addrs = policy
+        .pinned_addrs("93.184.216.34", 443)
+        .expect("public IP should validate");
+    assert_eq!(addrs.len(), 1);
+    assert_eq!(addrs[0].ip().to_string(), "93.184.216.34");
+    assert_eq!(addrs[0].port(), 443);
+
+    // allow_all does not resolve => empty pinned addrs (transport may resolve itself).
+    let permissive = DnsPolicy::allow_all();
+    assert!(permissive
+        .pinned_addrs("example.com", 443)
+        .unwrap()
+        .is_empty());
+}

--- a/specs/fetchers.md
+++ b/specs/fetchers.md
@@ -151,6 +151,27 @@ Central dispatcher that:
 - `"rss_feed"` - RSS/Atom feed entries
 - `"documentation"` - Documentation site content
 
+### HTTP Transport
+
+All fetchers perform their outbound HTTP exclusively through a pluggable
+`HttpTransport` (see `transport.rs`). The transport is a single-hop socket adapter:
+it never follows redirects and never performs DNS policy resolution. fetchkit owns
+URL validation, DNS policy (resolve-then-check, producing `TransportRequest.pinned_addrs`),
+manual per-hop redirect following, bot-auth signing, and body-size/timeout caps;
+only the socket-level send is delegated.
+
+`FetchOptions.transport` selects the implementation (`None` => default
+`ReqwestTransport`). A host application can supply its own transport to route
+fetchkit through a dedicated egress boundary without weakening any security policy.
+When `pinned_addrs` is non-empty a transport MUST connect only to those addresses
+(TM-SSRF-001, TM-SSRF-005).
+
+Hosts that consume fetchkit through the `Tool` surface inject the transport with
+`ToolBuilder::transport(Arc<dyn HttpTransport>)`; every Tool execution path
+(`execute`, `execute_with_status`, `execute_with_saver`, JSON `execution`/service)
+honors it, so the host keeps Tool's description/schema/llmtxt and FetchOptions
+assembly while owning egress.
+
 ### Configuration
 
 Fetchers receive `FetchOptions` for:

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -428,6 +428,7 @@ None — all previously open threats have been mitigated.
 | Script tag stripping | TM-CONV | Skip `script`/`style`/`noscript`/`iframe`/`svg` |
 | Binary detection | TM-CONV | Content-Type prefix matching |
 | New client per request | TM-NET | No connection pool state leakage |
+| Pluggable transport keeps policy in fetchkit | TM-SSRF, TM-NET | `HttpTransport` only performs the socket send; DNS policy (resolve-then-check), redirect following, and proxy suppression stay in fetchkit. `TransportRequest.pinned_addrs` (from `DnsPolicy`) constrains a custom transport to fetchkit-validated addresses; the default `ReqwestTransport` enforces this via `resolve_to_addrs()` |
 | Fetcher API URL hardcoding | TM-SSRF | Specialized fetchers (GitHub, Twitter) connect to hardcoded API hosts, not user-controlled URLs; DNS validation applied on initial connect |
 | Proxy env isolation | TM-NET | `reqwest::ClientBuilder::no_proxy()` by default |
 | Path traversal prevention | TM-INPUT | Lexical normalization plus save-time parent-directory symlink rejection in `LocalFileSaver` |


### PR DESCRIPTION
## What

Pluggable `HttpTransport` trait so hosts can route all fetchkit HTTP through their own egress boundary. fetchkit keeps URL validation, DNS policy (resolve-then-check producing `pinned_addrs`), manual per-hop redirect following, body caps/timeouts, bot-auth signing, and content conversion — only the socket-level send moves behind the trait.

## Why

Host applications (Everruns) need a single host-owned egress boundary for outbound traffic (policy, audit, signing). Everruns' egress path currently bypasses fetchkit's clients entirely and loses all specialized fetchers (everruns/everruns#2118). Transport injection restores them: fetchkit stays the request/response adapter, host owns transport.

## How

- `transport.rs`: `HttpTransport` trait, `TransportRequest` (method/url/headers/timeout/`pinned_addrs`/`respect_proxy_env`), streaming `TransportResponse`, `TransportError`, default `ReqwestTransport` preserving exact historical behavior (per-request client, no redirects, proxy env suppressed, `resolve_to_addrs` pinning).
- `FetchOptions.transport: Option<Arc<dyn HttpTransport>>` (None => ReqwestTransport); `ToolBuilder::transport()` for the Tool surface — all execution paths honor it.
- All 12 fetchers now do HTTP exclusively via the transport. Single hop per call; fetchkit validates every redirect hop.

## Security

- Strictly single-hop transport: never follows redirects, never resolves DNS policy — fetchkit owns both (TM-SSRF-001/005/010, TM-NET-003/004). Custom transports MUST connect only to `pinned_addrs` when non-empty.
- Strengthened: youtube/hackernews API hosts now DNS-pinned (previously unpinned); wikipedia/package_registry/arxiv/hackernews redirects now per-hop validated (previously reqwest-internal `Policy::limited(3)`); #131 subrequest policy enforcement preserved.
- Specialized-fetcher JSON reads now capped at `max_body_size` (previously unbounded `resp.json()`).
- THREAT comments updated; specs/fetchers.md + specs/threat-model.md updated.

## Validation

- fmt + clippy (`--all-targets --all-features -D warnings`) clean
- `cargo test` default + `bot-auth` features: all green (298 unit + suites; 8 transport tests incl. mock-transport Tool/DefaultFetcher/redirect/body-cap, pinned_addrs population)
- `--all-features` live-network tests: 4 pre-existing GitHub rate-limit failures, unrelated (hit real hosts via default transport)
- CLI smoke: `http://127.0.0.1` blocked; proxy env ignored by default