### PR TITLE
chore(release): prepare v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-04
+
+### Highlights
+
+- Bare host inputs such as `example.com` are now accepted and normalized before fetching.
+- URL handling is more consistent across direct and specialized fetcher paths, including docs pages.
+- Vulnerable Rust dependencies were updated.
+
+### What's Changed
+
+* fix: normalize direct fetcher URLs ([#141](https://github.com/everruns/fetchkit/pull/141))
+* fix(fetcher): respect docs page URLs ([#140](https://github.com/everruns/fetchkit/pull/140))
+* fix(deps): update vulnerable Rust dependencies ([#139](https://github.com/everruns/fetchkit/pull/139))
+* fix: accept bare host URLs ([#138](https://github.com/everruns/fetchkit/pull/138))
+
+**Full Changelog**: https://github.com/everruns/fetchkit/compare/v0.4.0...v0.4.1
+
 ## [0.4.0] - 2026-06-12
 
 ### Highlights
@@ -214,7 +231,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/everruns/fetchkit/commits/v0.1.0
 
-[Unreleased]: https://github.com/everruns/fetchkit/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/everruns/fetchkit/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/everruns/fetchkit/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/everruns/fetchkit/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/everruns/fetchkit/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/everruns/fetchkit/compare/v0.1.3...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fetchkit"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "fetchkit-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "fetchkit",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "fetchkit-python"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fetchkit",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/fetchkit-cli/Cargo.toml
+++ b/crates/fetchkit-cli/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 bot-auth = ["fetchkit/bot-auth"]
 
 [dependencies]
-fetchkit = { path = "../fetchkit", version = "0.4.0" }
+fetchkit = { path = "../fetchkit", version = "0.4.1" }
 tokio = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## What
Prepare FetchKit v0.4.1 patch release.

## Why
Ship the merged patch fixes since v0.4.0.

## How
- Bump workspace version to 0.4.1
- Update fetchkit-cli internal dependency pin
- Update Cargo.lock package versions
- Add v0.4.1 changelog section

## Risk
- Low
- Release metadata only; no runtime code changes in this PR

### Release Notes

### Highlights

- Bare host inputs such as `example.com` are now accepted and normalized before fetching.
- URL handling is more consistent across direct and specialized fetcher paths, including docs pages.
- Vulnerable Rust dependencies were updated.

### What's Changed

* fix: normalize direct fetcher URLs ([#141](https://github.com/everruns/fetchkit/pull/141))
* fix(fetcher): respect docs page URLs ([#140](https://github.com/everruns/fetchkit/pull/140))
* fix(deps): update vulnerable Rust dependencies ([#139](https://github.com/everruns/fetchkit/pull/139))
* fix: accept bare host URLs ([#138](https://github.com/everruns/fetchkit/pull/138))

## Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documenation is updated
- [x] Specs are up to date and not in conflict
- [x] Formatting passed
- [x] Clippy passed
- [x] Docs build passed with warnings denied
- [x] Release build smoke passed
