### PR TITLE
chore: standardize PR descriptions on functional change + before/after

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## What changed
+Describe the change functionally — what behavior changes and its impact on users
+or callers. Lead with outcomes; don't walk through code locations, the diff shows
+where and how. Keep any code-level notes short and specific.
+
+## Why
+Problem or motivation.
+
+## Before / After
+Show the effect with evidence. Include before and after whenever behavior changes —
+CLI/API output, logs, metrics, or screenshots for UI (attach working screenshots
+when possible). For changes with no observable behavior (pure refactor, docs), say so.
+
+## Risk
+- Low / Medium / High
+- What can break
+
+### Checklist
+- [ ] Unit tests are passed
+- [ ] Smoke tests are passed
+- [ ] Documentation is updated
+- [ ] Specs are up to date and not in conflict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,17 +262,25 @@ npx commitlint --from HEAD~1 --to HEAD
 
 PR titles should follow Conventional Commits format. Use the PR template (`.github/pull_request_template.md`) for descriptions.
 
+Center the description on functional change and impact, not a code-location
+walkthrough (the diff shows that). Add a Before / After with proof — CLI/API output,
+logs, metrics, or screenshots for UI — whenever behavior changes.
+
 **PR Body Template:**
 
 ```markdown
-## What
-Clear description of the change.
+## What changed
+Describe the change functionally — what behavior changes and its impact. Lead with
+outcomes; don't walk through code locations, the diff shows where and how. Keep any
+code-level notes short and specific.
 
 ## Why
 Problem or motivation.
 
-## How
-High-level approach.
+## Before / After
+Show the effect with evidence. Include before and after whenever behavior changes —
+CLI/API output, logs, metrics, or screenshots for UI (attach working screenshots
+when possible). For changes with no observable behavior (pure refactor, docs), say so.
 
 ## Risk
 - Low / Medium / High
@@ -281,9 +289,8 @@ High-level approach.
 ### Checklist
 - [ ] Unit tests are passed
 - [ ] Smoke tests are passed
-- [ ] Documenation is updated
+- [ ] Documentation is updated
 - [ ] Specs are up to date and not in conflict
-- [ ] ... other check list items
 ```
 
 ### Testing the system


### PR DESCRIPTION
## What changed

PR descriptions now center on **functional change and impact** instead of a code-location walkthrough, and the repo gains the `.github/pull_request_template.md` that `AGENTS.md` already referenced, with a **Before / After** section that asks for proof — CLI/API output, logs, metrics, or screenshots for UI. The inline PR-body template in `AGENTS.md` is updated to match (and a couple of typos fixed).

## Why

The diff already shows *where* and *how* code changed. A description should add what the diff can't: the behavior that changed, who it affects, and evidence it works — shifting effort from restating code to demonstrating impact.

## Before / After

Docs/templates only — no runtime behavior changes.

- **Before:** `AGENTS.md` referenced a template file that didn't exist; inline body used `## What` / `## How`.
- **After:** `## What changed` (functional summary + impact) + `## Before / After` (proof: output/logs/metrics, screenshots for UI when possible); template file now exists and matches `AGENTS.md`.

## Risk

- Low
- Documentation and PR-template only; no source, config, or CI logic touched.

## Checklist

- [x] Unit tests are passed — N/A (docs/templates only)
- [x] Smoke tests are passed — N/A
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict

---
_Generated by [Claude Code](https://claude.ai/code/session_013LSB82Db25Rf3tVPqWb1JQ)_