### PR TITLE
fix(save): validate file destinations before fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Stack Overflow question fetching now returns question and answer content again, including code snippets.
+- Invalid `save_to_file` destinations are rejected before any HTTP request or body download.
 
 ## [0.4.1] - 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ response = tool.fetch("https://example.com")
 | `method` | enum? | `GET` (default) or `HEAD` |
 | `as_markdown` | bool? | Convert HTML to markdown |
 | `as_text` | bool? | Convert HTML to plain text |
-| `save_to_file` | string? | Save body to path (requires `FileSaver`) |
+| `save_to_file` | string? | Non-blank destination path; validated by `FileSaver` before fetching |
 | `content_focus` | string? | `"full"`/unset returns everything; `"main"` strips semantic boilerplate; `"readable"` selects article-like content; `"agent"` selects the best low-noise strategy for AI agents |
 | `crawl` | bool? | Fetch the seed URL, then discover and fetch bounded same-origin pages |
 | `max_pages` | int? | Maximum crawl pages, including the seed; default 5, max 20 |

--- a/crates/fetchkit/src/convert.rs
+++ b/crates/fetchkit/src/convert.rs
@@ -1040,15 +1040,12 @@ fn find_matching_close(
                     .map(|ch| ch.is_ascii_whitespace() || ch == '>' || ch == '/')
                     .unwrap_or(false);
                 if is_same_tag {
-                    if let Some(end) = lower_html[open..].find('>') {
-                        let tag = &lower_html[open..open + end + 1];
-                        if !tag.ends_with("/>") {
-                            depth += 1;
-                        }
-                        cursor = open + end + 1;
-                    } else {
-                        return None;
+                    let end = lower_html[open..].find('>')?;
+                    let tag = &lower_html[open..open + end + 1];
+                    if !tag.ends_with("/>") {
+                        depth += 1;
                     }
+                    cursor = open + end + 1;
                 } else {
                     cursor = after_name;
                 }

--- a/crates/fetchkit/src/fetchers/default.rs
+++ b/crates/fetchkit/src/fetchers/default.rs
@@ -453,8 +453,8 @@ impl Fetcher for DefaultFetcher {
         options: &FetchOptions,
         saver: &dyn FileSaver,
     ) -> Result<FetchResponse, FetchError> {
-        let save_path = match &request.save_to_file {
-            Some(path) => path.clone(),
+        let save_path = match super::preflight_save_path(request, saver).await? {
+            Some(path) => path,
             None => return self.fetch(request, options).await,
         };
         let request = request.normalized_for_fetch()?;
@@ -511,7 +511,7 @@ impl Fetcher for DefaultFetcher {
 
         // Save through the FileSaver
         let save_result = saver
-            .save(&save_path, &body)
+            .save(save_path, &body)
             .await
             .map_err(|e| FetchError::SaveError(e.to_string()))?;
 

--- a/crates/fetchkit/src/fetchers/mod.rs
+++ b/crates/fetchkit/src/fetchers/mod.rs
@@ -75,8 +75,9 @@ pub trait Fetcher: Send + Sync {
         options: &FetchOptions,
         saver: &dyn FileSaver,
     ) -> Result<FetchResponse, FetchError> {
+        let save_path = preflight_save_path(request, saver).await?;
         let response = self.fetch(request, options).await?;
-        if let (Some(path), Some(content)) = (&request.save_to_file, &response.content) {
+        if let (Some(path), Some(content)) = (save_path, &response.content) {
             let result = saver
                 .save(path, content.as_bytes())
                 .await
@@ -242,9 +243,33 @@ impl FetcherRegistry {
     ) -> Result<FetchResponse, FetchError> {
         request.normalize_url_for_fetch()?;
         let (fetcher, _) = self.validate_and_find_fetcher(&request, &options)?;
+        preflight_save_path(&request, saver).await?;
         tracing::debug!(fetcher = fetcher.name(), url = %request.url, "Using fetcher (save to file)");
         fetcher.fetch_to_file(&request, &options, saver).await
     }
+}
+
+// THREAT[TM-INPUT-010]: Invalid file destinations must fail before any outbound request.
+// Mitigation: reject blank paths and invoke the adapter's preflight validation first.
+async fn preflight_save_path<'a>(
+    request: &'a FetchRequest,
+    saver: &dyn FileSaver,
+) -> Result<Option<&'a str>, FetchError> {
+    let Some(path) = request.save_to_file.as_deref() else {
+        return Ok(None);
+    };
+
+    if path.trim().is_empty() {
+        return Err(FetchError::SaveError(
+            "Path not allowed: Path must name a file".to_string(),
+        ));
+    }
+
+    saver
+        .validate_path(path)
+        .await
+        .map_err(|error| FetchError::SaveError(error.to_string()))?;
+    Ok(Some(path))
 }
 
 // THREAT[TM-INPUT-002]: URL-aware prefix matching normalizes both the URL and the prefix

--- a/crates/fetchkit/src/file_saver.rs
+++ b/crates/fetchkit/src/file_saver.rs
@@ -98,7 +98,7 @@ impl LocalFileSaver {
 
     /// Resolve and validate a path, returning the normalized absolute path.
     fn resolve_path(&self, path: &str) -> Result<PathBuf, FileSaveError> {
-        if path.is_empty() {
+        if path.trim().is_empty() {
             return Err(FileSaveError::PathNotAllowed(
                 "Path must name a file".into(),
             ));
@@ -129,6 +129,34 @@ impl LocalFileSaver {
                 ));
             }
             Ok(normalize_path(&input))
+        }
+    }
+
+    async fn validate_resolved_path(&self, resolved: &Path) -> Result<(), FileSaveError> {
+        if let Some(base_dir) = &self.base_dir {
+            if resolved == normalize_path(base_dir) {
+                return Err(FileSaveError::PathNotAllowed(format!(
+                    "Destination is the configured base directory, not a file: {}",
+                    resolved.display()
+                )));
+            }
+        }
+
+        if resolved.file_name().is_none() {
+            return Err(FileSaveError::PathNotAllowed(format!(
+                "Destination must name a file, not a root directory: {}",
+                resolved.display()
+            )));
+        }
+
+        match tokio::fs::symlink_metadata(resolved).await {
+            Ok(metadata) if metadata.is_dir() => Err(FileSaveError::PathNotAllowed(format!(
+                "Destination is a directory: {}",
+                resolved.display()
+            ))),
+            Ok(_) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -283,16 +311,7 @@ impl LocalFileSaver {
 impl FileSaver for LocalFileSaver {
     async fn save(&self, path: &str, bytes: &[u8]) -> Result<SaveResult, FileSaveError> {
         let resolved = self.resolve_path(path)?;
-        if let Some(base_dir) = &self.base_dir {
-            if resolved == normalize_path(base_dir) {
-                return Err(FileSaveError::PathNotAllowed(
-                    "Path must name a file".into(),
-                ));
-            }
-        }
-        resolved
-            .file_name()
-            .ok_or_else(|| FileSaveError::PathNotAllowed("Path must name a file".into()))?;
+        self.validate_resolved_path(&resolved).await?;
 
         let final_path = self.write_resolved_path(resolved, bytes).await?;
 
@@ -303,8 +322,8 @@ impl FileSaver for LocalFileSaver {
     }
 
     async fn validate_path(&self, path: &str) -> Result<(), FileSaveError> {
-        self.resolve_path(path)?;
-        Ok(())
+        let resolved = self.resolve_path(path)?;
+        self.validate_resolved_path(&resolved).await
     }
 }
 
@@ -625,5 +644,29 @@ mod tests {
         assert!(saver.validate_path("safe.txt").await.is_ok());
         assert!(saver.validate_path("sub/dir/safe.txt").await.is_ok());
         assert!(saver.validate_path("../../escape.txt").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_local_file_saver_validate_path_rejects_non_file_destinations() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("existing")).unwrap();
+        let saver = LocalFileSaver::new(Some(dir.path().to_path_buf()));
+
+        for path in ["", "   ", ".", "existing"] {
+            let error = saver.validate_path(path).await.unwrap_err();
+            assert!(matches!(error, FileSaveError::PathNotAllowed(_)), "{path}");
+        }
+
+        let error = saver.validate_path("existing").await.unwrap_err();
+        assert!(error.to_string().contains("Destination is a directory"));
+    }
+
+    #[tokio::test]
+    async fn test_local_file_saver_validate_path_rejects_root_destination() {
+        let saver = LocalFileSaver::new(None);
+        let error = saver.validate_path("/").await.unwrap_err();
+
+        assert!(matches!(error, FileSaveError::PathNotAllowed(_)));
+        assert!(error.to_string().contains("root directory"));
     }
 }

--- a/crates/fetchkit/src/tool.rs
+++ b/crates/fetchkit/src/tool.rs
@@ -846,7 +846,9 @@ fn build_input_schema(
             "save_to_file".to_string(),
             json!({
                 "type": "string",
-                "description": "Adapter-defined destination path"
+                "description": "Adapter-defined destination path",
+                "minLength": 1,
+                "pattern": "\\S"
             }),
         );
     }

--- a/crates/fetchkit/tests/integration.rs
+++ b/crates/fetchkit/tests/integration.rs
@@ -2,7 +2,7 @@
 
 use fetchkit::{
     fetch_with_options, DnsPolicy, FetchError, FetchOptions, FetchRequest, FetcherRegistry,
-    HttpMethod, LocalFileSaver, Tool,
+    FileSaveError, FileSaver, HttpMethod, LocalFileSaver, SaveResult, Tool,
 };
 use serde_json::json;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -32,6 +32,21 @@ fn test_tool_with_save() -> Tool {
         .block_private_ips(false)
         .enable_save_to_file(true)
         .build()
+}
+
+struct RejectingFileSaver;
+
+#[async_trait::async_trait]
+impl FileSaver for RejectingFileSaver {
+    async fn save(&self, _path: &str, _bytes: &[u8]) -> Result<SaveResult, FileSaveError> {
+        panic!("save must not run after failed path validation");
+    }
+
+    async fn validate_path(&self, _path: &str) -> Result<(), FileSaveError> {
+        Err(FileSaveError::PathNotAllowed(
+            "rejected by test saver".to_string(),
+        ))
+    }
 }
 
 async fn spawn_malformed_chunked_server() -> String {
@@ -1018,6 +1033,51 @@ async fn test_save_to_file_rejects_path_traversal() {
 }
 
 #[tokio::test]
+async fn test_save_to_file_rejects_invalid_path_before_request() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("should not be fetched"))
+        .mount(&mock_server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let saver = LocalFileSaver::new(Some(dir.path().to_path_buf()));
+    let req = FetchRequest::new(format!("{}/", mock_server.uri())).save_to_file(" \t\n ");
+
+    let error = test_tool_with_save()
+        .execute_with_saver(req, Some(&saver))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, FetchError::SaveError(_)));
+    assert!(error.to_string().contains("Path must name a file"));
+    assert!(mock_server.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_save_to_file_invokes_saver_validation_before_request() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("should not be fetched"))
+        .mount(&mock_server)
+        .await;
+
+    let req = FetchRequest::new(format!("{}/", mock_server.uri())).save_to_file("blocked.txt");
+    let error = test_tool_with_save()
+        .execute_with_saver(req, Some(&RejectingFileSaver))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, FetchError::SaveError(_)));
+    assert!(error.to_string().contains("rejected by test saver"));
+    assert!(mock_server.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn test_save_to_file_without_saver_errors() {
     let tool = test_tool_with_save();
 
@@ -1060,6 +1120,8 @@ async fn test_save_to_file_schema_gating() {
     let schema = tool.input_schema();
     if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
         assert!(props.contains_key("save_to_file"));
+        assert_eq!(props["save_to_file"]["minLength"], 1);
+        assert_eq!(props["save_to_file"]["pattern"], "\\S");
     }
 }
 

--- a/specs/fetchers.md
+++ b/specs/fetchers.md
@@ -13,7 +13,7 @@ Each fetcher must implement:
 1. **`name()`** - Unique identifier string for logging/debugging
 2. **`matches(url)`** - Returns true if this fetcher handles the URL
 3. **`fetch(request, options)`** - Async fetch returning `FetchResponse` or error
-4. **`fetch_to_file(request, options, saver)`** - Optional. Default implementation calls `fetch()` then saves string content via `FileSaver`. Fetchers may override for binary-aware saving (e.g., `DefaultFetcher` accepts binary content when saving to file).
+4. **`fetch_to_file(request, options, saver)`** - Optional. Path validation runs before fetching. Default implementation then calls `fetch()` and saves string content via `FileSaver`. Fetchers may override for binary-aware saving (e.g., `DefaultFetcher` accepts binary content when saving to file).
 
 ### Fetcher Registry
 

--- a/specs/initial.md
+++ b/specs/initial.md
@@ -73,7 +73,8 @@ Provide a builder to configure tool options, including:
   - `method: HttpMethod` (optional, default GET)
   - `as_markdown: bool` (optional, feature-gated)
   - `as_text: bool` (optional, feature-gated)
-  - `save_to_file: Option<String>` (optional, feature-gated via `enable_save_to_file`)
+  - `save_to_file: Option<String>` (optional, feature-gated via `enable_save_to_file`;
+    when present, must contain at least one non-whitespace character)
   - `content_focus: Option<String>` controls extraction before HTML conversion:
     - `"full"` or unset returns everything
     - `"main"` strips semantic boilerplate
@@ -320,6 +321,8 @@ By default, Fetchkit blocks connections to private/reserved IP ranges:
 #### Save to File
 
 When `save_to_file` is set on the request:
+- Empty and whitespace-only destinations are rejected.
+- `FileSaver::validate_path` runs before any HTTP request or body download.
 - Binary content is NOT rejected (accepted for file saves).
 - Raw bytes are saved via the `FileSaver` trait implementation.
 - Response includes `saved_path` and `bytes_written` instead of `content`.
@@ -327,6 +330,7 @@ When `save_to_file` is set on the request:
 - The `FileSaver` trait provides path validation (traversal prevention) and async save.
 - `LocalFileSaver` is the built-in implementation for CLI/local use:
   - Resolves paths relative to a configurable base directory.
+  - Rejects the configured base directory, root-like paths, and existing directories as destinations.
   - Rejects path traversal via lexical normalization and save-time symlink checks.
   - Creates parent directories as needed.
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -220,6 +220,7 @@ expected outbound path.
 | TM-INPUT-007 | Block prefix matching is string-based, not URL-aware | Medium | URL-aware prefix matching compares parsed components (scheme, host, path) | MITIGATED |
 | TM-INPUT-008 | Symlink-based path traversal in LocalFileSaver | Medium | Save-time parent-directory walk rejects symlinks and re-checks canonical path under base_dir | MITIGATED |
 | TM-INPUT-009 | LocalFileSaver without base_dir allows arbitrary writes | Medium | Documented limitation; callers should always set base_dir in untrusted contexts | **ACCEPTED** |
+| TM-INPUT-010 | Invalid save destination triggers unnecessary network/body download | Low | Schema rejects blank strings; runtime calls `FileSaver::validate_path` before transport | MITIGATED |
 
 ### Mitigation Details
 
@@ -258,8 +259,8 @@ matching). `http://internal.example.com` correctly does NOT match
 save-time enforcement now walks each parent directory component under `base_dir`
 using directory handles, rejects symlinks with no-follow opens, and opens the
 final file relative to the verified parent with no-follow semantics.
-`execute_with_saver()` no longer performs a separate `validate_path()` preflight,
-so path checks now happen at write time instead of in a validate-then-write split.
+`execute_with_saver()` also performs `validate_path()` preflight before transport;
+the descriptor-anchored save-time checks remain authoritative against path changes.
 
 **TM-INPUT-009 — No base_dir allows arbitrary writes (ACCEPTED):**
 `LocalFileSaver::new(None)` only requires absolute paths, with no directory restriction.
@@ -267,6 +268,14 @@ Accepted because:
 - This mode is for CLI/trusted contexts only
 - The `FileSaver` trait allows custom implementations with stricter controls
 - `enable_save_to_file` is disabled by default
+
+**TM-INPUT-010 — Save destination preflight (MITIGATED):**
+The input schema requires `save_to_file` to contain at least one non-whitespace
+character. Runtime execution independently rejects blank destinations and calls
+the configured `FileSaver::validate_path` before any HTTP request or body download.
+`LocalFileSaver` preflight also rejects its configured base directory, root-like
+destinations, and existing directories. Save-time no-follow checks remain in place
+to protect against changes between validation and write.
 
 ## 4. Denial of Service (TM-DOS)
 
@@ -435,7 +444,7 @@ None — all previously open threats have been mitigated.
 | Pluggable transport keeps policy in fetchkit | TM-SSRF, TM-NET | `HttpTransport` only performs the socket send; DNS policy (resolve-then-check), redirect following, and proxy suppression stay in fetchkit. `TransportRequest.pinned_addrs` (from `DnsPolicy`) constrains a custom transport to fetchkit-validated addresses; the default `ReqwestTransport` enforces this via `resolve_to_addrs()` |
 | Fetcher API URL hardcoding | TM-SSRF | Specialized fetchers (GitHub, Twitter) connect to hardcoded API hosts, not user-controlled URLs; DNS validation applied on initial connect |
 | Proxy env isolation | TM-NET | `reqwest::ClientBuilder::no_proxy()` by default |
-| Path traversal prevention | TM-INPUT | Lexical normalization plus save-time parent-directory symlink rejection in `LocalFileSaver` |
+| Path traversal prevention | TM-INPUT | Preflight destination validation, lexical normalization, and save-time parent-directory symlink rejection in `LocalFileSaver` |
 | Save feature gating | TM-INPUT | `enable_save_to_file` disabled by default; schema gated |
 | Bot-auth feature gating | TM-AUTH | `bot-auth` Cargo feature disabled by default; no crypto deps unless opted in |
 | Rendered fetch feature gating | TM-SSRF, TM-NET, TM-DOS | Browser-rendered fetching disabled by default; lightweight rakers-style rendering must be gated by `render-rakers`, require an explicit request/config switch, apply fetchkit URL, DNS, proxy, timeout, and body-size policy to the initial page, and deny rakers-initiated subresource network requests unless they can be routed through fetchkit policy |


### PR DESCRIPTION
## What changed
Invalid `save_to_file` destinations are rejected before any HTTP request or body download. The tool schema now rejects empty and whitespace-only values, and `LocalFileSaver` rejects base-directory, root-like, and existing-directory destinations with precise path errors.

Valid downloads and normal inline fetches are unchanged.

## Why
The fetch pipeline did not call the preflight hook promised by `FileSaver::validate_path`. Invalid destinations could therefore trigger network traffic and full body downloads before failing, while whitespace paths could be accepted as filenames.

## Before / After
Before: a whitespace-only destination fetched the response and wrote a whitespace filename; custom validation failures were discovered only at save time or not called at all.

After: schema and runtime validation reject invalid destinations, adapter validation runs before transport, and regression tests verify the HTTP server receives zero requests on validation failure.

## Risk
- Low
- Stricter validation can reject callers that previously passed blank strings or directories as file destinations. Valid file paths retain existing behavior.

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict