### PR TITLE
fix(fetcher): cap rendered rakers output

### DIFF
--- a/crates/fetchkit/src/fetchers/default.rs
+++ b/crates/fetchkit/src/fetchers/default.rs
@@ -334,12 +334,17 @@ impl Fetcher for DefaultFetcher {
         // Determine format and convert if needed
         // THREAT[TM-DOS-006]: Conversion input is bounded by max_body_size
         let is_html_content = is_html(&meta.content_type, &content);
+        let mut rendered_truncated = false;
         let rendered_by = if is_html_content && request.wants_rakers_render() {
             content = render_html_with_rakers(content, final_url.clone(), options).await?;
+            // THREAT[TM-DOS-006]: Rendering can expand a small page; re-apply the
+            // body-size cap before metadata extraction or conversion.
+            rendered_truncated = truncate_string_to_max_bytes(&mut content, max_body_size);
             Some("rakers".to_string())
         } else {
             None
         };
+        let truncated = truncated || rendered_truncated;
         let is_paywall = detect_paywall(&content);
         let wants_main = request.wants_main_content();
         let wants_readable = request.wants_readable_content();
@@ -699,6 +704,19 @@ fn validate_rakers_render_request(
     {
         Err(FetchError::RenderNotAvailable)
     }
+}
+
+fn truncate_string_to_max_bytes(content: &mut String, max_size: usize) -> bool {
+    if content.len() <= max_size {
+        return false;
+    }
+
+    let mut end = max_size;
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    content.truncate(end);
+    true
 }
 
 #[cfg(feature = "render-rakers")]

--- a/crates/fetchkit/tests/integration.rs
+++ b/crates/fetchkit/tests/integration.rs
@@ -238,6 +238,43 @@ async fn test_render_rakers_executes_inline_js_before_markdown_conversion() {
 
 #[cfg(feature = "render-rakers")]
 #[tokio::test]
+async fn test_render_rakers_output_is_capped_before_conversion() {
+    let server = MockServer::start().await;
+    let html = r#"<!doctype html>
+<html>
+  <body>
+    <main><p>small</p></main>
+    <script>
+      document.body.innerHTML = '<main>' + '<p>expanded</p>'.repeat(2000) + '</main>';
+    </script>
+  </body>
+</html>"#;
+
+    Mock::given(method("GET"))
+        .and(path("/spa"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(html, "text/html"))
+        .mount(&server)
+        .await;
+
+    let tool = Tool::builder()
+        .block_private_ips(false)
+        .max_body_size(1024)
+        .enable_render_rakers(true)
+        .build();
+    let response = tool
+        .execute(FetchRequest::new(format!("{}/spa", server.uri())).render_rakers())
+        .await
+        .unwrap();
+
+    assert_eq!(response.rendered_by.as_deref(), Some("rakers"));
+    assert_eq!(response.truncated, Some(true));
+    let content = response.content.unwrap();
+    assert!(content.len() <= 1024 + "\n\n[..content truncated...]".len());
+    assert!(content.contains("[..content truncated...]"));
+}
+
+#[cfg(feature = "render-rakers")]
+#[tokio::test]
 async fn test_render_rakers_does_not_fetch_page_subresources() {
     let server = MockServer::start().await;
     let html = r#"<!doctype html>

--- a/specs/fetchers.md
+++ b/specs/fetchers.md
@@ -195,6 +195,8 @@ markdown/text conversion path.
   complete DOM/CSS engine.
 - Must honor fetchkit URL validation, allow/block lists, DNS policy, proxy
   policy, timeout policy, and body-size limits for the initial page.
+- Must re-apply the configured body-size limit to rendered HTML before
+  metadata extraction, boilerplate stripping, or markdown/text conversion.
 - Must not let the rakers runtime bypass fetchkit egress policy. Until
   subresource fetches can be routed through fetchkit policy, rakers-initiated
   external script, fetch, and XHR requests must be denied.

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -438,7 +438,7 @@ None — all previously open threats have been mitigated.
 | Path traversal prevention | TM-INPUT | Lexical normalization plus save-time parent-directory symlink rejection in `LocalFileSaver` |
 | Save feature gating | TM-INPUT | `enable_save_to_file` disabled by default; schema gated |
 | Bot-auth feature gating | TM-AUTH | `bot-auth` Cargo feature disabled by default; no crypto deps unless opted in |
-| Rendered fetch feature gating | TM-SSRF, TM-NET, TM-DOS | Browser-rendered fetching disabled by default; lightweight rakers-style rendering must be gated by `render-rakers`, require an explicit request/config switch, apply fetchkit URL, DNS, proxy, timeout, and body-size policy to the initial page, and deny rakers-initiated subresource network requests unless they can be routed through fetchkit policy |
+| Rendered fetch feature gating | TM-SSRF, TM-NET, TM-DOS | Browser-rendered fetching disabled by default; lightweight rakers-style rendering must be gated by `render-rakers`, require an explicit request/config switch, apply fetchkit URL, DNS, proxy, timeout, and body-size policy to the initial page, re-apply body-size policy to rendered HTML before conversion, and deny rakers-initiated subresource network requests unless they can be routed through fetchkit policy |
 | Signature nonce + timestamps | TM-AUTH | 32-byte random nonce + created/expires per signature prevents replay |
 | Authority-scoped signatures | TM-AUTH | Signature covers `@authority`; per-host binding |
 | Graceful signing failure | TM-AUTH | Signing errors logged, request proceeds unsigned |


### PR DESCRIPTION
### Motivation
- The optional `rakers` rendering path could expand a small fetched HTML payload via inline JavaScript into an unbounded post-render string, bypassing the configured `max_body_size` and enabling CPU/memory amplification (DoS) during metadata extraction and conversion.

### Description
- Re-apply the configured body-size cap after `rakers` rendering and before any metadata extraction or conversion by truncating the rendered HTML to `max_body_size` and marking the response truncated. 
- Add a UTF-8-safe helper `truncate_string_to_max_bytes` to trim rendered `String` content at a character boundary. 
- Set the existing `truncated` response signal when rendered output is capped and preserve `rendered_by = Some("rakers")`. 
- Add a regression test `test_render_rakers_output_is_capped_before_conversion` that verifies rendered output is capped and `truncated` is set, and update `specs/fetchers.md` and `specs/threat-model.md` to require re-applying body-size limits after rendering.

### Testing
- Ran `cargo test --workspace` and all tests passed (306 passed total including the new render-rakers regression test). 
- Ran targeted `cargo test -p fetchkit --features render-rakers test_render_rakers_output_is_capped_before_conversion` and the test passed. 
- Ran linting `cargo clippy --workspace --all-targets -- -D warnings` and `cargo clippy -p fetchkit --features render-rakers --all-targets -- -D warnings` with no warnings. 
- Built docs and release artifacts with `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` and `cargo build --workspace --exclude fetchkit-python --release`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c78f13424832b93859b2334f0b31c)