### PR TITLE
fix(crawl): enforce same-origin redirects

### DIFF
--- a/crates/fetchkit/src/client.rs
+++ b/crates/fetchkit/src/client.rs
@@ -41,6 +41,9 @@ pub struct FetchOptions {
     pub blocked_hosts: Vec<String>,
     /// Restrict redirects to the original host only.
     pub same_host_redirects_only: bool,
+    /// Internal crawl boundary: redirects must stay on this exact origin.
+    #[doc(hidden)]
+    pub redirect_origin: Option<Url>,
     /// Enable rakers-rendered HTML fetching. The request must still opt in.
     pub enable_render_rakers: bool,
     /// Web Bot Authentication config (draft-meunier-web-bot-auth-architecture).
@@ -72,6 +75,7 @@ impl std::fmt::Debug for FetchOptions {
             .field("allowed_ports", &self.allowed_ports)
             .field("blocked_hosts", &self.blocked_hosts)
             .field("same_host_redirects_only", &self.same_host_redirects_only)
+            .field("redirect_origin", &self.redirect_origin)
             .field("enable_render_rakers", &self.enable_render_rakers);
         #[cfg(feature = "bot-auth")]
         d.field("bot_auth", &self.bot_auth);
@@ -114,6 +118,15 @@ impl FetchOptions {
             && normalized_host(current_url) != normalized_host(next_url)
         {
             return Err(FetchError::BlockedUrl);
+        }
+
+        if let Some(origin) = &self.redirect_origin {
+            let same_origin = origin.scheme() == next_url.scheme()
+                && normalized_host(origin) == normalized_host(next_url)
+                && origin.port_or_known_default() == next_url.port_or_known_default();
+            if !same_origin {
+                return Err(FetchError::BlockedUrl);
+            }
         }
 
         Ok(())

--- a/crates/fetchkit/src/crawl.rs
+++ b/crates/fetchkit/src/crawl.rs
@@ -47,7 +47,10 @@ pub(crate) async fn crawl_fetch_with_options(
         let mut page_request = FetchRequest::new(url.as_str()).as_markdown();
         page_request.content_focus = Some("agent".to_string());
 
-        match registry.fetch(page_request, options.clone()).await {
+        let mut page_options = options.clone();
+        page_options.redirect_origin = Some(discovery_base_url.clone());
+
+        match registry.fetch(page_request, page_options).await {
             Ok(response) => pages.push(page_from_response(&response)),
             Err(err) => pages.push(CrawlPage {
                 url: url.to_string(),
@@ -182,6 +185,61 @@ mod tests {
             .iter()
             .any(|page| page.url.ends_with("/docs") && page.title.as_deref() == Some("Docs")));
         assert_eq!(crawl.truncated, None);
+    }
+
+    #[tokio::test]
+    async fn test_crawl_blocks_redirects_outside_seed_origin() {
+        let seed_server = MockServer::start().await;
+        let attacker_server = MockServer::start().await;
+        let attacker_url = format!("{}/landing", attacker_server.uri());
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string(r#"<html><head><title>Home</title></head><body><a href="/go">Go</a></body></html>"#),
+            )
+            .mount(&seed_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/go"))
+            .respond_with(ResponseTemplate::new(302).insert_header("location", attacker_url))
+            .mount(&seed_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/landing"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string("<title>Attacker</title>"),
+            )
+            .mount(&attacker_server)
+            .await;
+
+        let options = FetchOptions {
+            enable_markdown: true,
+            dns_policy: DnsPolicy::allow_all(),
+            ..Default::default()
+        };
+        let response = crawl_fetch_with_options(
+            FetchRequest::new(seed_server.uri())
+                .crawl(true)
+                .max_pages(5),
+            options,
+        )
+        .await
+        .unwrap();
+
+        let crawl = response.crawl.unwrap();
+        assert_eq!(crawl.pages.len(), 2);
+        assert!(crawl.pages.iter().any(|page| {
+            page.url.ends_with("/go")
+                && page.error.as_deref() == Some("Blocked URL: not allowed by policy")
+        }));
+        assert!(!crawl.pages.iter().any(|page| page
+            .url
+            .contains(&attacker_server.address().port().to_string())));
     }
 
     #[test]

--- a/crates/fetchkit/src/tool.rs
+++ b/crates/fetchkit/src/tool.rs
@@ -670,6 +670,7 @@ impl Tool {
             allowed_ports: self.allowed_ports.clone(),
             blocked_hosts: self.blocked_hosts.clone(),
             same_host_redirects_only: self.same_host_redirects_only,
+            redirect_origin: None,
             enable_render_rakers: self.enable_render_rakers,
             #[cfg(feature = "bot-auth")]
             bot_auth: self.bot_auth.clone(),


### PR DESCRIPTION
### Motivation

- Prevent crawl-discovered page fetches from leaving the seed origin via redirects and exposing cross-origin metadata. 
- Preserve existing caller-configured redirect behavior for direct fetches while hardening the opt-in crawl path.

### Description

- Add internal `redirect_origin: Option<Url>` to `FetchOptions` and expose it in debug output to carry a per-fetch origin boundary. 
- Enforce the crawl boundary in `FetchOptions::validate_redirect_target` by rejecting redirect targets whose scheme, normalized host, or default-aware port differ from the configured `redirect_origin`. 
- When fetching discovered crawl pages, set `page_options.redirect_origin = Some(discovery_base_url.clone())` so per-hop redirect validation is constrained to the seed origin. 
- Add a regression test `test_crawl_blocks_redirects_outside_seed_origin` that exercises a same-origin link which redirects to an attacker origin and asserts the crawl records a blocked error and does not include attacker metadata. 
- Ensure `Tool::build_options` leaves `redirect_origin` unset (`None`) for normal tool usage so default behavior is unchanged.

### Testing

- Ran the new regression test `crawl::tests::test_crawl_blocks_redirects_outside_seed_origin` and it passed. 
- Ran unit and workspace tests with `cargo test --workspace` and all tests passed (307 passed). 
- Ran lints with `cargo clippy --workspace --all-targets -- -D warnings` and it passed. 
- Ran docs build `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` and `cargo build --workspace --exclude fetchkit-python --release` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c7fbd45f4832b8859794cafc1f6c7)