### PR TITLE
feat(fetchers): add Jupyter notebook fetcher

### DIFF
--- a/crates/fetchkit/src/fetchers/jupyter_notebook.rs
+++ b/crates/fetchkit/src/fetchers/jupyter_notebook.rs
@@ -1,0 +1,308 @@
+//! Jupyter notebook fetcher for GitHub and GitLab blob URLs.
+
+use crate::client::FetchOptions;
+use crate::error::FetchError;
+use crate::fetchers::default::{read_full_body, transport_request};
+use crate::fetchers::Fetcher;
+use crate::types::{FetchRequest, FetchResponse};
+use crate::DEFAULT_USER_AGENT;
+use async_trait::async_trait;
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
+use serde_json::Value;
+use std::time::Duration;
+use url::Url;
+
+const TIMEOUT: Duration = Duration::from_secs(15);
+const DEFAULT_MAX_BODY_SIZE: usize = 5 * 1024 * 1024;
+
+pub struct JupyterNotebookFetcher;
+
+impl JupyterNotebookFetcher {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn raw_url(url: &Url) -> Option<(Url, &'static str)> {
+        let segments: Vec<&str> = url.path_segments()?.collect();
+        if !segments.last()?.to_ascii_lowercase().ends_with(".ipynb") {
+            return None;
+        }
+        match url.host_str()? {
+            "github.com" if segments.len() >= 5 && segments[2] == "blob" => {
+                let raw = format!(
+                    "https://raw.githubusercontent.com/{}/{}/{}/{}",
+                    segments[0],
+                    segments[1],
+                    segments[3],
+                    segments[4..].join("/")
+                );
+                Some((Url::parse(&raw).ok()?, "raw.githubusercontent.com"))
+            }
+            "gitlab.com" => {
+                let marker = segments.iter().position(|part| *part == "-")?;
+                if marker < 2
+                    || segments.get(marker + 1) != Some(&"blob")
+                    || marker + 4 > segments.len()
+                {
+                    return None;
+                }
+                let raw = format!(
+                    "https://gitlab.com/{}/-/raw/{}/{}",
+                    segments[..marker].join("/"),
+                    segments[marker + 2],
+                    segments[marker + 3..].join("/")
+                );
+                Some((Url::parse(&raw).ok()?, "gitlab.com"))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl Default for JupyterNotebookFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Fetcher for JupyterNotebookFetcher {
+    fn name(&self) -> &'static str {
+        "jupyter_notebook"
+    }
+    fn matches(&self, url: &Url) -> bool {
+        Self::raw_url(url).is_some()
+    }
+
+    async fn fetch(
+        &self,
+        request: &FetchRequest,
+        options: &FetchOptions,
+    ) -> Result<FetchResponse, FetchError> {
+        let request = request.normalized_for_fetch()?;
+        let page_url = Url::parse(&request.url).map_err(|_| FetchError::InvalidUrlScheme)?;
+        let (raw_url, host) = Self::raw_url(&page_url)
+            .ok_or_else(|| FetchError::FetcherError("Not a supported notebook URL".into()))?;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            USER_AGENT,
+            HeaderValue::from_str(options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT))
+                .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT)),
+        );
+        let response = transport_request(
+            raw_url,
+            reqwest::Method::GET,
+            headers,
+            options,
+            TIMEOUT,
+            host,
+            443,
+        )
+        .await?;
+        let status_code = response.status;
+        if !(200..300).contains(&status_code) {
+            return Ok(FetchResponse {
+                url: request.url,
+                status_code,
+                error: Some(format!("Notebook source returned HTTP {status_code}")),
+                ..Default::default()
+            });
+        }
+        let body = read_full_body(response, options).await?;
+        let notebook: Value = serde_json::from_slice(&body).map_err(|error| {
+            FetchError::FetcherError(format!("Invalid Jupyter notebook: {error}"))
+        })?;
+        let title = page_url
+            .path_segments()
+            .and_then(|mut parts| parts.next_back())
+            .unwrap_or("Notebook");
+        let content = render_notebook(title, &notebook)?;
+        let (content, truncated) = truncate(
+            content,
+            options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE),
+        );
+        let size = u64::try_from(content.len()).unwrap_or(u64::MAX);
+        Ok(FetchResponse {
+            url: request.url,
+            status_code,
+            content_type: Some("text/markdown".into()),
+            format: Some("jupyter_notebook".into()),
+            content: Some(content),
+            size: Some(size),
+            truncated: Some(truncated),
+            ..Default::default()
+        })
+    }
+}
+
+fn source(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::String(value)) => value.clone(),
+        Some(Value::Array(lines)) => lines.iter().filter_map(Value::as_str).collect(),
+        _ => String::new(),
+    }
+}
+
+fn render_notebook(title: &str, notebook: &Value) -> Result<String, FetchError> {
+    let cells = notebook
+        .get("cells")
+        .and_then(Value::as_array)
+        .ok_or_else(|| FetchError::FetcherError("Notebook has no cells array".into()))?;
+    let language = notebook
+        .pointer("/metadata/language_info/name")
+        .and_then(Value::as_str)
+        .unwrap_or("python");
+    let mut out = format!(
+        "# {title}\n\n- **Kernel language:** {language}\n- **Cells:** {}\n\n",
+        cells.len()
+    );
+    for cell in cells {
+        match cell.get("cell_type").and_then(Value::as_str) {
+            Some("markdown") => {
+                out.push_str(&source(cell.get("source")));
+                out.push_str("\n\n");
+            }
+            Some("code") => {
+                let code = source(cell.get("source"));
+                let count = cell
+                    .get("execution_count")
+                    .and_then(Value::as_u64)
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| " ".into());
+                out.push_str(&format!(
+                    "## In [{count}]\n\n{}\n\n",
+                    fenced(language, &code)
+                ));
+                let outputs: Vec<String> = cell
+                    .get("outputs")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(text_output)
+                    .collect();
+                if !outputs.is_empty() {
+                    out.push_str(&format!(
+                        "### Output\n\n{}\n\n",
+                        fenced("text", &outputs.join("\n"))
+                    ));
+                }
+            }
+            Some("raw") => {
+                out.push_str(&format!(
+                    "{}\n\n",
+                    fenced("text", &source(cell.get("source")))
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+fn text_output(output: &Value) -> Option<String> {
+    match output.get("output_type").and_then(Value::as_str) {
+        Some("stream") => Some(source(output.get("text"))),
+        Some("error") => {
+            let traceback = source(output.get("traceback"));
+            if traceback.is_empty() {
+                Some(format!(
+                    "{}: {}",
+                    output.get("ename")?.as_str()?,
+                    output.get("evalue")?.as_str()?
+                ))
+            } else {
+                Some(traceback)
+            }
+        }
+        Some("execute_result" | "display_data") => {
+            let data = output.get("data")?;
+            let text = source(data.get("text/plain"));
+            (!text.is_empty()).then_some(text)
+        }
+        _ => None,
+    }
+}
+
+fn fenced(language: &str, content: &str) -> String {
+    let longest = content
+        .split(|character| character != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+    let fence = "`".repeat(longest.max(2) + 1);
+    format!("{fence}{language}\n{content}\n{fence}")
+}
+
+fn truncate(mut value: String, max: usize) -> (String, bool) {
+    if value.len() <= max {
+        return (value, false);
+    }
+    let mut end = max;
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value.truncate(end);
+    (value, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_github_and_nested_gitlab_blob_urls_to_raw_sources() {
+        let (url, host) = JupyterNotebookFetcher::raw_url(
+            &Url::parse("https://github.com/org/repo/blob/main/notebooks/demo.ipynb").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://raw.githubusercontent.com/org/repo/main/notebooks/demo.ipynb"
+        );
+        assert_eq!(host, "raw.githubusercontent.com");
+        let (url, host) = JupyterNotebookFetcher::raw_url(
+            &Url::parse("https://gitlab.com/group/sub/repo/-/blob/dev/demo.ipynb").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://gitlab.com/group/sub/repo/-/raw/dev/demo.ipynb"
+        );
+        assert_eq!(host, "gitlab.com");
+    }
+
+    #[test]
+    fn rejects_non_notebooks_and_unsupported_hosts() {
+        for input in [
+            "https://github.com/org/repo/blob/main/demo.py",
+            "https://example.com/demo.ipynb",
+            "https://gitlab.com/org/repo/-/blob/main",
+        ] {
+            assert!(JupyterNotebookFetcher::raw_url(&Url::parse(input).unwrap()).is_none());
+        }
+    }
+
+    #[test]
+    fn renders_markdown_code_text_outputs_and_errors_but_not_images() {
+        let notebook = serde_json::json!({"metadata":{"language_info":{"name":"rust"}},"cells":[
+            {"cell_type":"markdown","source":["## Intro\n","Hello"]},
+            {"cell_type":"code","execution_count":2,"source":"println!(\"hi\");","outputs":[
+                {"output_type":"stream","text":["hi\n"]},
+                {"output_type":"display_data","data":{"text/plain":"chart","image/png":"AAAA"}},
+                {"output_type":"error","ename":"Error","evalue":"bad","traceback":["Error: bad"]}
+            ]}
+        ]});
+        let output = render_notebook("demo.ipynb", &notebook).unwrap();
+        assert!(output.contains("## Intro\nHello"));
+        assert!(output.contains("## In [2]"));
+        assert!(output.contains("```rust\nprintln!"));
+        assert!(output.contains("hi\n\nchart\nError: bad"));
+        assert!(!output.contains("AAAA"));
+    }
+
+    #[test]
+    fn chooses_safe_fence_and_utf8_truncation() {
+        assert!(fenced("text", "``` inside").starts_with("````text"));
+        assert_eq!(truncate("aéz".into(), 2), ("a".into(), true));
+    }
+}

--- a/crates/fetchkit/src/fetchers/mod.rs
+++ b/crates/fetchkit/src/fetchers/mod.rs
@@ -12,6 +12,7 @@ mod github_release;
 mod github_repo;
 mod gitlab;
 mod hackernews;
+mod jupyter_notebook;
 mod package_registry;
 mod rss_feed;
 mod stackoverflow;
@@ -28,6 +29,7 @@ pub use github_release::GitHubReleaseFetcher;
 pub use github_repo::GitHubRepoFetcher;
 pub use gitlab::GitLabFetcher;
 pub use hackernews::HackerNewsFetcher;
+pub use jupyter_notebook::JupyterNotebookFetcher;
 pub use package_registry::PackageRegistryFetcher;
 pub use rss_feed::RSSFeedFetcher;
 pub use stackoverflow::StackOverflowFetcher;
@@ -136,18 +138,21 @@ impl FetcherRegistry {
     /// Create a registry with default fetchers pre-registered
     ///
     /// Includes (in order of priority):
-    /// 1. GitHubCodeFetcher - handles GitHub blob/file URLs
-    /// 2. GitHubIssueFetcher - handles GitHub issue/PR URLs
-    /// 3. GitHubReleaseFetcher - handles GitHub release URLs
-    /// 4. GitHubRepoFetcher - handles GitHub repository URLs
-    /// 5. GitLabFetcher - handles GitLab project and resource URLs
-    /// 6. TwitterFetcher - handles Twitter/X tweet URLs
-    /// 7. StackOverflowFetcher - handles Stack Exchange Q&A URLs
-    /// 8. DocsSiteFetcher - handles docs sites and llms.txt URLs
-    /// 9. DefaultFetcher - handles all remaining HTTP/HTTPS URLs
+    /// 1. JupyterNotebookFetcher - handles GitHub and GitLab notebook blob URLs
+    /// 2. GitHubCodeFetcher - handles GitHub blob/file URLs
+    /// 3. GitHubIssueFetcher - handles GitHub issue/PR URLs
+    /// 4. GitHubReleaseFetcher - handles GitHub release URLs
+    /// 5. GitHubRepoFetcher - handles GitHub repository URLs
+    /// 6. GitLabFetcher - handles GitLab project and resource URLs
+    /// 7. TwitterFetcher - handles Twitter/X tweet URLs
+    /// 8. StackOverflowFetcher - handles Stack Exchange Q&A URLs
+    /// 9. DocsSiteFetcher - handles docs sites and llms.txt URLs
+    /// 10. DefaultFetcher - handles all remaining HTTP/HTTPS URLs
     pub fn with_defaults() -> Self {
         let mut registry = Self::new();
         // Register specialized fetchers first (higher priority)
+        // Notebooks precede the generic GitHub and GitLab blob fetchers.
+        registry.register(Box::new(JupyterNotebookFetcher::new()));
         // GitHub fetchers: code > issue > release > repo (most specific first)
         registry.register(Box::new(GitHubCodeFetcher::new()));
         registry.register(Box::new(GitHubIssueFetcher::new()));
@@ -346,22 +351,23 @@ mod tests {
     #[test]
     fn test_registry_with_defaults() {
         let registry = FetcherRegistry::with_defaults();
-        assert_eq!(registry.fetchers[0].name(), "github_code");
-        assert_eq!(registry.fetchers[1].name(), "github_issue");
-        assert_eq!(registry.fetchers[2].name(), "github_release");
-        assert_eq!(registry.fetchers[3].name(), "github_repo");
-        assert_eq!(registry.fetchers[4].name(), "gitlab");
-        assert_eq!(registry.fetchers[5].name(), "twitter_tweet");
-        assert_eq!(registry.fetchers[6].name(), "stackoverflow");
-        assert_eq!(registry.fetchers[7].name(), "package_registry");
-        assert_eq!(registry.fetchers[8].name(), "wikipedia");
-        assert_eq!(registry.fetchers[9].name(), "youtube");
-        assert_eq!(registry.fetchers[10].name(), "arxiv");
-        assert_eq!(registry.fetchers[11].name(), "hackernews");
-        assert_eq!(registry.fetchers[12].name(), "rss_feed");
-        assert_eq!(registry.fetchers[13].name(), "docs_site");
-        assert_eq!(registry.fetchers[14].name(), "default");
-        assert_eq!(registry.fetchers.len(), 15);
+        assert_eq!(registry.fetchers[0].name(), "jupyter_notebook");
+        assert_eq!(registry.fetchers[1].name(), "github_code");
+        assert_eq!(registry.fetchers[2].name(), "github_issue");
+        assert_eq!(registry.fetchers[3].name(), "github_release");
+        assert_eq!(registry.fetchers[4].name(), "github_repo");
+        assert_eq!(registry.fetchers[5].name(), "gitlab");
+        assert_eq!(registry.fetchers[6].name(), "twitter_tweet");
+        assert_eq!(registry.fetchers[7].name(), "stackoverflow");
+        assert_eq!(registry.fetchers[8].name(), "package_registry");
+        assert_eq!(registry.fetchers[9].name(), "wikipedia");
+        assert_eq!(registry.fetchers[10].name(), "youtube");
+        assert_eq!(registry.fetchers[11].name(), "arxiv");
+        assert_eq!(registry.fetchers[12].name(), "hackernews");
+        assert_eq!(registry.fetchers[13].name(), "rss_feed");
+        assert_eq!(registry.fetchers[14].name(), "docs_site");
+        assert_eq!(registry.fetchers[15].name(), "default");
+        assert_eq!(registry.fetchers.len(), 16);
     }
 
     #[test]

--- a/specs/fetchers.md
+++ b/specs/fetchers.md
@@ -85,6 +85,15 @@ Central dispatcher that:
 - Quoted tweets rendered as blockquotes
 - Both APIs are unauthenticated; syndication API is undocumented but widely used
 
+#### JupyterNotebookFetcher
+
+- Matches `.ipynb` source blob URLs on GitHub and GitLab
+- Runs before generic GitHub and GitLab source fetchers
+- Renders Markdown, code, raw cells, execution counts, and textual outputs as Markdown
+- Omits binary display payloads such as base64-encoded images
+- Uses collision-safe Markdown fences and enforces the configured maximum response size
+- Response format field: `"jupyter_notebook"`
+
 #### GitHubCodeFetcher
 
 - Matches: `https://github.com/{owner}/{repo}/blob/{ref}/{path}`


### PR DESCRIPTION
## What changed
Render Jupyter notebooks hosted as GitHub or GitLab blobs into compact Markdown. Markdown, code, and raw cells are preserved along with execution counts and textual outputs; binary display payloads are omitted.

## Why
Raw notebook JSON and repository HTML are noisy for agents. Notebook-aware conversion exposes the narrative, executable code, and useful results directly.

## Before / After
**Before:** `.ipynb` URLs were treated as generic source files or GitLab blobs, returning raw notebook JSON.

**After:** They return `format: jupyter_notebook` with a notebook summary, rendered cells, collision-safe code fences, and UTF-8-safe size limits.

Proof:
```text
cargo test --workspace: passed
cargo clippy --workspace --all-targets -- -D warnings: passed
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps: passed
cargo build --workspace --exclude fetchkit-python --release: passed
```

## Risk
- Low
- Rich outputs intentionally include only `text/plain`; embedded image data is omitted to keep responses bounded and useful to LLMs.

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict

Produced by [yolop](https://everruns.com/yolop)
