### PR TITLE
feat(fetchers): add IETF RFC fetcher

### DIFF
--- a/crates/fetchkit/src/fetchers/ietf_rfc.rs
+++ b/crates/fetchkit/src/fetchers/ietf_rfc.rs
@@ -1,0 +1,203 @@
+//! IETF RFC fetcher using canonical RFC Editor plain-text publications.
+
+use crate::client::FetchOptions;
+use crate::error::FetchError;
+use crate::fetchers::default::{read_full_body, transport_request};
+use crate::fetchers::Fetcher;
+use crate::types::{FetchRequest, FetchResponse};
+use crate::DEFAULT_USER_AGENT;
+use async_trait::async_trait;
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
+use std::time::Duration;
+use url::Url;
+
+const TIMEOUT: Duration = Duration::from_secs(15);
+const DEFAULT_MAX_BODY_SIZE: usize = 5 * 1024 * 1024;
+
+pub struct IetfRfcFetcher;
+
+impl IetfRfcFetcher {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn rfc_number(url: &Url) -> Option<u32> {
+        let host = url.host_str()?;
+        let segments: Vec<&str> = url
+            .path_segments()?
+            .filter(|segment| !segment.is_empty())
+            .collect();
+        let candidate = match host {
+            "datatracker.ietf.org" => match segments.as_slice() {
+                ["doc", "html", value] | ["doc", value] => *value,
+                _ => return None,
+            },
+            "www.rfc-editor.org" | "rfc-editor.org" => match segments.as_slice() {
+                ["rfc", value] => *value,
+                _ => return None,
+            },
+            "www.ietf.org" | "ietf.org" => match segments.as_slice() {
+                ["rfc", value] => *value,
+                _ => return None,
+            },
+            "tools.ietf.org" => match segments.as_slice() {
+                ["html", value] => *value,
+                _ => return None,
+            },
+            _ => return None,
+        };
+        parse_rfc(candidate)
+    }
+}
+
+impl Default for IetfRfcFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Fetcher for IetfRfcFetcher {
+    fn name(&self) -> &'static str {
+        "ietf_rfc"
+    }
+
+    fn matches(&self, url: &Url) -> bool {
+        Self::rfc_number(url).is_some()
+    }
+
+    async fn fetch(
+        &self,
+        request: &FetchRequest,
+        options: &FetchOptions,
+    ) -> Result<FetchResponse, FetchError> {
+        let request = request.normalized_for_fetch()?;
+        let page_url = Url::parse(&request.url).map_err(|_| FetchError::InvalidUrlScheme)?;
+        let number = Self::rfc_number(&page_url)
+            .ok_or_else(|| FetchError::FetcherError("Not a supported RFC URL".into()))?;
+        let source_url = Url::parse(&format!("https://www.rfc-editor.org/rfc/rfc{number}.txt"))
+            .map_err(|_| FetchError::InvalidUrlScheme)?;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            USER_AGENT,
+            HeaderValue::from_str(options.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT))
+                .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT)),
+        );
+        headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
+        let response = transport_request(
+            source_url,
+            reqwest::Method::GET,
+            headers,
+            options,
+            TIMEOUT,
+            "www.rfc-editor.org",
+            443,
+        )
+        .await?;
+        let status_code = response.status;
+        if !(200..300).contains(&status_code) {
+            return Ok(FetchResponse {
+                url: request.url,
+                status_code,
+                error: Some(match status_code {
+                    404 => format!("RFC {number} not found"),
+                    _ => format!("RFC Editor returned HTTP {status_code}"),
+                }),
+                ..Default::default()
+            });
+        }
+        let body = read_full_body(response, options).await?;
+        let content = String::from_utf8(body.to_vec())
+            .map_err(|_| FetchError::FetcherError("RFC publication is not valid UTF-8".into()))?;
+        let content = normalize_text(&content);
+        let (content, truncated) = truncate(
+            content,
+            options.max_body_size.unwrap_or(DEFAULT_MAX_BODY_SIZE),
+        );
+        let size = u64::try_from(content.len()).unwrap_or(u64::MAX);
+        Ok(FetchResponse {
+            url: request.url,
+            status_code,
+            content_type: Some("text/plain".into()),
+            format: Some("ietf_rfc".into()),
+            content: Some(content),
+            size: Some(size),
+            truncated: Some(truncated),
+            ..Default::default()
+        })
+    }
+}
+
+fn parse_rfc(value: &str) -> Option<u32> {
+    let value = value
+        .strip_suffix(".html")
+        .or_else(|| value.strip_suffix(".txt"))
+        .or_else(|| value.strip_suffix(".xml"))
+        .unwrap_or(value);
+    let digits = value
+        .strip_prefix("rfc")
+        .or_else(|| value.strip_prefix("RFC"))?;
+    let number = digits.parse::<u32>().ok()?;
+    (number > 0).then_some(number)
+}
+
+fn normalize_text(value: &str) -> String {
+    value.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn truncate(mut value: String, max: usize) -> (String, bool) {
+    if value.len() <= max {
+        return (value, false);
+    }
+    let mut end = max;
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value.truncate(end);
+    (value, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_supported_rfc_urls() {
+        for input in [
+            "https://datatracker.ietf.org/doc/html/rfc9110",
+            "https://datatracker.ietf.org/doc/rfc9110/",
+            "https://www.rfc-editor.org/rfc/rfc9110.html",
+            "https://www.rfc-editor.org/rfc/rfc9110.txt",
+            "https://www.ietf.org/rfc/rfc9110.txt",
+            "https://tools.ietf.org/html/rfc9110",
+        ] {
+            assert_eq!(
+                IetfRfcFetcher::rfc_number(&Url::parse(input).unwrap()),
+                Some(9110),
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_rfc_and_malformed_urls() {
+        for input in [
+            "https://datatracker.ietf.org/doc/draft-example/",
+            "https://www.rfc-editor.org/",
+            "https://www.rfc-editor.org/rfc/rfc0.txt",
+            "https://www.rfc-editor.org/rfc/rfcnope.txt",
+            "https://example.com/rfc9110",
+        ] {
+            assert!(
+                IetfRfcFetcher::rfc_number(&Url::parse(input).unwrap()).is_none(),
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalizes_line_endings_and_truncates_utf8_safely() {
+        assert_eq!(normalize_text("one\r\ntwo\rthree"), "one\ntwo\nthree");
+        assert_eq!(truncate("aéz".into(), 2), ("a".into(), true));
+    }
+}

--- a/crates/fetchkit/src/fetchers/mod.rs
+++ b/crates/fetchkit/src/fetchers/mod.rs
@@ -13,6 +13,7 @@ mod github_release;
 mod github_repo;
 mod gitlab;
 mod hackernews;
+mod ietf_rfc;
 mod jupyter_notebook;
 mod package_registry;
 mod pubmed;
@@ -32,6 +33,7 @@ pub use github_release::GitHubReleaseFetcher;
 pub use github_repo::GitHubRepoFetcher;
 pub use gitlab::GitLabFetcher;
 pub use hackernews::HackerNewsFetcher;
+pub use ietf_rfc::IetfRfcFetcher;
 pub use jupyter_notebook::JupyterNotebookFetcher;
 pub use package_registry::PackageRegistryFetcher;
 pub use pubmed::PubMedFetcher;
@@ -170,6 +172,7 @@ impl FetcherRegistry {
         registry.register(Box::new(YouTubeFetcher::new()));
         registry.register(Box::new(ArXivFetcher::new()));
         registry.register(Box::new(CrossrefFetcher::new()));
+        registry.register(Box::new(IetfRfcFetcher::new()));
         registry.register(Box::new(PubMedFetcher::new()));
         registry.register(Box::new(HackerNewsFetcher::new()));
         registry.register(Box::new(RSSFeedFetcher::new()));
@@ -370,12 +373,13 @@ mod tests {
         assert_eq!(registry.fetchers[10].name(), "youtube");
         assert_eq!(registry.fetchers[11].name(), "arxiv");
         assert_eq!(registry.fetchers[12].name(), "crossref");
-        assert_eq!(registry.fetchers[13].name(), "pubmed");
-        assert_eq!(registry.fetchers[14].name(), "hackernews");
-        assert_eq!(registry.fetchers[15].name(), "rss_feed");
-        assert_eq!(registry.fetchers[16].name(), "docs_site");
-        assert_eq!(registry.fetchers[17].name(), "default");
-        assert_eq!(registry.fetchers.len(), 18);
+        assert_eq!(registry.fetchers[13].name(), "ietf_rfc");
+        assert_eq!(registry.fetchers[14].name(), "pubmed");
+        assert_eq!(registry.fetchers[15].name(), "hackernews");
+        assert_eq!(registry.fetchers[16].name(), "rss_feed");
+        assert_eq!(registry.fetchers[17].name(), "docs_site");
+        assert_eq!(registry.fetchers[18].name(), "default");
+        assert_eq!(registry.fetchers.len(), 19);
     }
 
     #[test]

--- a/specs/fetchers.md
+++ b/specs/fetchers.md
@@ -138,6 +138,14 @@ Central dispatcher that:
 - Behavior: Fetches paper metadata via arXiv Atom XML API
 - Response format field: `"arxiv_paper"`
 
+#### IetfRfcFetcher
+
+- Matches canonical RFC URLs on IETF Datatracker, RFC Editor, IETF, and legacy IETF Tools hosts
+- Normalizes the RFC number and retrieves the canonical plain-text publication from RFC Editor
+- Preserves section numbering, ASCII diagrams, references, and status boilerplate
+- Normalizes line endings and enforces the configured response limit
+- Response format field: `"ietf_rfc"`
+
 #### CrossrefFetcher
 
 - Matches DOI resolver URLs on `doi.org` and legacy `dx.doi.org`


### PR DESCRIPTION
## What changed
Fetch RFC URLs from IETF Datatracker, RFC Editor, IETF, and legacy IETF Tools as canonical RFC Editor plain text.

## Why
Generic HTML conversion can alter RFC section layout and ASCII diagrams. The canonical text publication preserves the normative document structure, references, and status boilerplate.

## Before / After
**Before:** RFC pages used generic HTML conversion and varied by source host.

**After:** Supported RFC URLs normalize to the RFC number and return `format: ietf_rfc` with canonical plain text, normalized line endings, and UTF-8-safe response limits.

Proof:
```text
cargo test --workspace: passed
cargo clippy --workspace --all-targets -- -D warnings: passed
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps: passed
cargo build --workspace --exclude fetchkit-python --release: passed
```

## Risk
- Low
- Relies on canonical text publication availability at RFC Editor.
- Internet-Draft URLs intentionally remain handled by generic fetching.

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict

Produced by [yolop](https://everruns.com/yolop)
