### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+## [0.5.0] - 2026-07-14
 
-- Optional `render-rakers` feature for explicit, per-request lightweight JS/DOM rendering before markdown/text conversion. The backend is disabled by default, exposed only when a host enables it, and denies rakers-initiated subresource network requests.
+### Highlights
 
-### Fixed
+- Added opt-in lightweight JavaScript/DOM rendering through the `render-rakers` feature, with subresource network requests denied.
+- Restored Stack Overflow question and answer extraction, including code snippets.
+- Hardened local file saving by rejecting invalid destinations before fetching or downloading content.
 
-- Stack Overflow question fetching now returns question and answer content again, including code snippets.
-- Invalid `save_to_file` destinations are rejected before any HTTP request or body download.
+### What's Changed
+
+* feat(render): add opt-in rakers backend ([#145](https://github.com/everruns/fetchkit/pull/145))
+* fix(fetchers): restore Stack Overflow extraction ([#144](https://github.com/everruns/fetchkit/pull/144))
+* fix(fetchkit): preflight local save destinations ([#143](https://github.com/everruns/fetchkit/pull/143))
+
+**Full Changelog**: https://github.com/everruns/fetchkit/compare/v0.4.1...v0.5.0
 
 ## [0.4.1] - 2026-07-04
 
@@ -240,7 +247,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/everruns/fetchkit/commits/v0.1.0
 
-[Unreleased]: https://github.com/everruns/fetchkit/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/everruns/fetchkit/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/everruns/fetchkit/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/everruns/fetchkit/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/everruns/fetchkit/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/everruns/fetchkit/compare/v0.2.0...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fetchkit"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "fetchkit-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "fetchkit",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "fetchkit-python"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "fetchkit",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/fetchkit-cli/Cargo.toml
+++ b/crates/fetchkit-cli/Cargo.toml
@@ -22,7 +22,7 @@ bot-auth = ["fetchkit/bot-auth"]
 render-rakers = ["fetchkit/render-rakers"]
 
 [dependencies]
-fetchkit = { path = "../fetchkit", version = "0.4.1" }
+fetchkit = { path = "../fetchkit", version = "0.5.0" }
 tokio = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## What changed
Prepare the v0.5.0 release with updated workspace/package versions and release notes covering the opt-in rakers renderer, restored Stack Overflow extraction, and local-save preflight validation.

## Why
Ship the user-facing changes merged since v0.4.1 through the repository's automated GitHub Release and crates.io publication workflow.

## Before / After
Before: publishable crates and changelog identify v0.4.1.

After: publishable crates identify v0.5.0, and the changelog links the complete v0.4.1...v0.5.0 change set.

## Risk
- Low
- Version metadata or release-note errors could produce an incorrect release artifact.

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict

Produced by [yolop](https://everruns.com/yolop)
