### PR TITLE
fix(fetchers): enforce GitHub commit API URL policy

### DIFF
--- a/crates/fetchkit/src/fetchers/github_commit.rs
+++ b/crates/fetchkit/src/fetchers/github_commit.rs
@@ -3,7 +3,7 @@
 use crate::client::FetchOptions;
 use crate::error::FetchError;
 use crate::fetchers::default::{read_full_body, transport_request};
-use crate::fetchers::Fetcher;
+use crate::fetchers::{validate_url_policy, Fetcher};
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
@@ -176,6 +176,7 @@ impl Fetcher for GitHubCommitFetcher {
             ),
         };
         let api_url = api_url(owner, repo, endpoint, &label)?;
+        validate_url_policy(&api_url, options)?;
         let response = transport_request(
             api_url,
             reqwest::Method::GET,

--- a/crates/fetchkit/src/fetchers/mod.rs
+++ b/crates/fetchkit/src/fetchers/mod.rs
@@ -210,30 +210,7 @@ impl FetcherRegistry {
 
         let parsed_url = Url::parse(&request.url).map_err(|_| FetchError::InvalidUrlScheme)?;
 
-        options.validate_url(&parsed_url)?;
-
-        // THREAT[TM-INPUT-002]: Normalize URL before prefix matching to prevent
-        // encoding-based bypasses (case, trailing dots, default ports)
-        // THREAT[TM-INPUT-007]: URL-aware prefix matching prevents subdomain tricks
-        if !options.allow_prefixes.is_empty() {
-            let allowed = options
-                .allow_prefixes
-                .iter()
-                .any(|prefix| url_matches_policy_prefix(&parsed_url, prefix));
-            if !allowed {
-                debug!(url = %request.url, "URL not in allow list");
-                return Err(FetchError::BlockedUrl);
-            }
-        }
-
-        if options
-            .block_prefixes
-            .iter()
-            .any(|prefix| url_matches_policy_prefix(&parsed_url, prefix))
-        {
-            debug!(url = %request.url, "URL matched block list");
-            return Err(FetchError::BlockedUrl);
-        }
+        validate_url_policy(&parsed_url, options)?;
 
         for fetcher in &self.fetchers {
             if fetcher.matches(&parsed_url) {
@@ -275,6 +252,39 @@ impl FetcherRegistry {
         tracing::debug!(fetcher = fetcher.name(), url = %request.url, "Using fetcher (save to file)");
         fetcher.fetch_to_file(&request, &options, saver).await
     }
+}
+
+/// Validate all operator URL policy for a request destination.
+///
+/// Specialized fetchers that derive secondary API URLs must call this before
+/// transport_request so allow/block/host/port policy applies to every egress hop.
+pub(crate) fn validate_url_policy(url: &Url, options: &FetchOptions) -> Result<(), FetchError> {
+    options.validate_url(url)?;
+
+    // THREAT[TM-INPUT-002]: Normalize URL before prefix matching to prevent
+    // encoding-based bypasses (case, trailing dots, default ports)
+    // THREAT[TM-INPUT-007]: URL-aware prefix matching prevents subdomain tricks
+    if !options.allow_prefixes.is_empty() {
+        let allowed = options
+            .allow_prefixes
+            .iter()
+            .any(|prefix| url_matches_policy_prefix(url, prefix));
+        if !allowed {
+            debug!(url = %url, "URL not in allow list");
+            return Err(FetchError::BlockedUrl);
+        }
+    }
+
+    if options
+        .block_prefixes
+        .iter()
+        .any(|prefix| url_matches_policy_prefix(url, prefix))
+    {
+        debug!(url = %url, "URL matched block list");
+        return Err(FetchError::BlockedUrl);
+    }
+
+    Ok(())
 }
 
 // THREAT[TM-INPUT-010]: Invalid file destinations must fail before any outbound request.

--- a/crates/fetchkit/tests/transport.rs
+++ b/crates/fetchkit/tests/transport.rs
@@ -7,8 +7,8 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use fetchkit::{
-    ArXivFetcher, DefaultFetcher, DnsPolicy, DocsSiteFetcher, FetchError, FetchOptions,
-    FetchRequest, Fetcher, GitHubCodeFetcher, GitHubIssueFetcher, GitHubRepoFetcher,
+    fetch_with_options, ArXivFetcher, DefaultFetcher, DnsPolicy, DocsSiteFetcher, FetchError,
+    FetchOptions, FetchRequest, Fetcher, GitHubCodeFetcher, GitHubIssueFetcher, GitHubRepoFetcher,
     HackerNewsFetcher, HttpMethod, HttpTransport, PackageRegistryFetcher, RSSFeedFetcher,
     StackOverflowFetcher, TransportError, TransportMethod, TransportRequest, TransportResponse,
     TwitterFetcher, WikipediaFetcher, YouTubeFetcher,
@@ -298,6 +298,22 @@ async fn default_fetcher_enforces_body_cap_on_transport_stream() {
     assert!(content.starts_with("aaaaaaaaaa"));
     assert!(content.contains("content truncated"));
     assert_eq!(response.size, Some(10));
+}
+
+#[tokio::test]
+async fn github_commit_fetcher_enforces_policy_on_api_subrequest() {
+    let mock = Arc::new(MockTransport::new());
+    let mut options = options_with(mock.clone());
+    options.allow_prefixes = vec!["http://github.com".to_string()];
+    options.block_prefixes = vec!["https://api.github.com".to_string()];
+    options.blocked_hosts = vec!["api.github.com".to_string()];
+    options.allowed_ports = vec![80];
+
+    let request = FetchRequest::new("http://github.com/everruns/fetchkit/commit/deadbeef");
+    let result = fetch_with_options(request, options).await;
+
+    assert!(matches!(result, Err(FetchError::BlockedUrl)));
+    assert!(mock.calls().is_empty());
 }
 
 #[tokio::test]

--- a/specs/fetchers.md
+++ b/specs/fetchers.md
@@ -24,7 +24,8 @@ Central dispatcher that:
 3. Falls back to default fetcher if none match
 4. Provides `register()` for adding custom fetchers
 5. Validates URL scheme and allow/block lists before dispatching
-6. Provides `fetch_to_file()` that dispatches to matched fetcher's `fetch_to_file()`
+6. Provides shared URL-policy validation for fetchers that derive secondary API URLs; every outbound destination must satisfy the same host, port, allow-prefix, and block-prefix policy before transport execution
+7. Provides `fetch_to_file()` that dispatches to matched fetcher's `fetch_to_file()`
 
 ### Built-in Fetchers
 
@@ -47,6 +48,7 @@ Central dispatcher that:
 - Uses GitHub's REST API for commit metadata, authorship, signature verification, changed-file statistics, and patches
 - Comparison responses include ahead/behind counts, merge base, and included commits
 - Limits each patch excerpt to 2,000 Unicode characters and enforces the configured overall response limit
+- Enforces full URL policy on the derived `https://api.github.com` request before transport execution
 - Response format field: `"github_commit"` or `"github_compare"`
 
 #### GitHubActionsRunFetcher


### PR DESCRIPTION
### Motivation

- The GitHub commit/compare fetcher derived a secondary `https://api.github.com:443` URL and sent it via `transport_request` without re-checking operator `FetchOptions` policy, allowing an egress bypass of host/port/prefix restrictions.
- Operator-configured allow/block prefixes, `blocked_hosts`, and `allowed_ports` must apply to every outbound hop, including API subrequests produced by specialized fetchers.
- Prevent accidental API egress when a deployment allows only an original `github.com` URL (for example `http://github.com:80`) but disallows `api.github.com:443`.

### Description

- Add a shared `validate_url_policy(url, options)` helper in `crates/fetchkit/src/fetchers/mod.rs` that runs `options.validate_url` plus prefix and block-prefix checks and return `BlockedUrl` on violation.
- Replace the registry's inline URL policy logic with a call to `validate_url_policy` and call `validate_url_policy` in `crates/fetchkit/src/fetchers/github_commit.rs` before the `transport_request` to the GitHub API.
- Add a regression test `github_commit_fetcher_enforces_policy_on_api_subrequest` in `crates/fetchkit/tests/transport.rs` and update `specs/fetchers.md` to document that fetchers deriving secondary API URLs must enforce the same host/port/prefix policy.

### Testing

- Ran the focused transport test `cargo test -p fetchkit --test transport github_commit_fetcher_enforces_policy_on_api_subrequest` which passed and asserts the injected transport received zero calls when policy blocks the API URL.
- Ran the full test suite `cargo test --workspace` which completed successfully with all tests passing (`343 passed` reported in this run).
- Verified static checks and artifacts via `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, and `cargo build --workspace --exclude fetchkit-python --release`, all of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ba54cf510832b8c8296ceefe40d18)