### PR TITLE
fix(fetchers): validate Crossref API policy

### DIFF
--- a/crates/fetchkit/src/fetchers/crossref.rs
+++ b/crates/fetchkit/src/fetchers/crossref.rs
@@ -4,7 +4,7 @@ use crate::client::FetchOptions;
 use crate::convert::html_to_markdown;
 use crate::error::FetchError;
 use crate::fetchers::default::{read_full_body, transport_request};
-use crate::fetchers::Fetcher;
+use crate::fetchers::{validate_url_policy, Fetcher};
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
@@ -67,7 +67,7 @@ impl Fetcher for CrossrefFetcher {
             .path_segments_mut()
             .map_err(|_| FetchError::InvalidUrlScheme)?
             .push(&doi);
-        options.validate_url(&api_url)?;
+        validate_url_policy(&api_url, options)?;
         let mut headers = HeaderMap::new();
         headers.insert(
             USER_AGENT,

--- a/crates/fetchkit/src/fetchers/crossref.rs
+++ b/crates/fetchkit/src/fetchers/crossref.rs
@@ -67,6 +67,7 @@ impl Fetcher for CrossrefFetcher {
             .path_segments_mut()
             .map_err(|_| FetchError::InvalidUrlScheme)?
             .push(&doi);
+        options.validate_url(&api_url)?;
         let mut headers = HeaderMap::new();
         headers.insert(
             USER_AGENT,
@@ -264,6 +265,32 @@ mod tests {
         ] {
             assert!(CrossrefFetcher::doi(&Url::parse(input).unwrap()).is_none());
         }
+    }
+
+    #[tokio::test]
+    async fn blocks_crossref_api_host_policy_before_transport() {
+        let fetcher = CrossrefFetcher::new();
+        let request = FetchRequest::new("https://doi.org/10.1000/test");
+        let options = FetchOptions {
+            blocked_hosts: vec!["api.crossref.org".to_string()],
+            ..Default::default()
+        };
+
+        let result = fetcher.fetch(&request, &options).await;
+        assert!(matches!(result, Err(FetchError::BlockedUrl)));
+    }
+
+    #[tokio::test]
+    async fn blocks_crossref_api_port_policy_before_transport() {
+        let fetcher = CrossrefFetcher::new();
+        let request = FetchRequest::new("http://doi.org/10.1000/test");
+        let options = FetchOptions {
+            allowed_ports: vec![80],
+            ..Default::default()
+        };
+
+        let result = fetcher.fetch(&request, &options).await;
+        assert!(matches!(result, Err(FetchError::BlockedUrl)));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The Crossref DOI fetcher constructed a derived `https://api.crossref.org/works/...` URL and dispatched it to the transport without applying the configured egress policy, allowing `blocked_hosts` or `allowed_ports` to be bypassed.
- Enforce operator policies for the secondary API hop to prevent unintended egress to `api.crossref.org:443` when operators have blocked that host or disallowed that port.

### Description
- Validate the derived Crossref API URL with `options.validate_url(&api_url)?;` before calling `transport_request` in `crates/fetchkit/src/fetchers/crossref.rs`.
- Add regression tests `blocks_crossref_api_host_policy_before_transport` and `blocks_crossref_api_port_policy_before_transport` to ensure blocked host and disallowed port policies cause `FetchError::BlockedUrl` for DOI requests.
- Change is policy-only and preserves existing DOI metadata fetching when operator policies allow `api.crossref.org:443`.

### Testing
- Ran `cargo test -p fetchkit crossref --lib` and the new Crossref tests passed.
- Ran `cargo test --workspace` and all workspace tests passed (no failures).
- Ran `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5baab2b070832b989cba9b51f45e21)