### PR TITLE
fix(fetchers): validate notebook raw URLs

### DIFF
--- a/crates/fetchkit/src/fetchers/jupyter_notebook.rs
+++ b/crates/fetchkit/src/fetchers/jupyter_notebook.rs
@@ -83,6 +83,7 @@ impl Fetcher for JupyterNotebookFetcher {
         let page_url = Url::parse(&request.url).map_err(|_| FetchError::InvalidUrlScheme)?;
         let (raw_url, host) = Self::raw_url(&page_url)
             .ok_or_else(|| FetchError::FetcherError("Not a supported notebook URL".into()))?;
+        options.validate_url(&raw_url)?;
         let mut headers = HeaderMap::new();
         headers.insert(
             USER_AGENT,
@@ -248,6 +249,35 @@ fn truncate(mut value: String, max: usize) -> (String, bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dns::DnsPolicy;
+    use crate::transport::{HttpTransport, TransportError, TransportRequest, TransportResponse};
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use futures::stream;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[derive(Default)]
+    struct CountingTransport {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl HttpTransport for CountingTransport {
+        async fn execute(
+            &self,
+            req: TransportRequest,
+        ) -> Result<TransportResponse, TransportError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let body = br#"{"metadata":{},"cells":[]}"#.to_vec();
+            Ok(TransportResponse {
+                status: 200,
+                url: req.url,
+                headers: vec![("content-type".into(), "application/json".into())],
+                body: Box::pin(stream::once(async move { Ok(Bytes::from(body)) })),
+            })
+        }
+    }
 
     #[test]
     fn maps_github_and_nested_gitlab_blob_urls_to_raw_sources() {
@@ -304,5 +334,47 @@ mod tests {
     fn chooses_safe_fence_and_utf8_truncation() {
         assert!(fenced("text", "``` inside").starts_with("````text"));
         assert_eq!(truncate("aéz".into(), 2), ("a".into(), true));
+    }
+
+    #[tokio::test]
+    async fn validates_rewritten_github_raw_host_before_transport() {
+        let transport = Arc::new(CountingTransport::default());
+        let options = FetchOptions {
+            blocked_hosts: vec!["raw.githubusercontent.com".into()],
+            dns_policy: DnsPolicy::allow_all(),
+            transport: Some(transport.clone()),
+            ..Default::default()
+        };
+
+        let result = JupyterNotebookFetcher::new()
+            .fetch(
+                &FetchRequest::new("https://github.com/org/repo/blob/main/demo.ipynb"),
+                &options,
+            )
+            .await;
+
+        assert!(matches!(result, Err(FetchError::BlockedUrl)));
+        assert_eq!(transport.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn validates_rewritten_github_raw_port_before_transport() {
+        let transport = Arc::new(CountingTransport::default());
+        let options = FetchOptions {
+            allowed_ports: vec![80],
+            dns_policy: DnsPolicy::allow_all(),
+            transport: Some(transport.clone()),
+            ..Default::default()
+        };
+
+        let result = JupyterNotebookFetcher::new()
+            .fetch(
+                &FetchRequest::new("https://github.com:80/org/repo/blob/main/demo.ipynb"),
+                &options,
+            )
+            .await;
+
+        assert!(matches!(result, Err(FetchError::BlockedUrl)));
+        assert_eq!(transport.calls.load(Ordering::SeqCst), 0);
     }
 }

--- a/crates/fetchkit/src/fetchers/jupyter_notebook.rs
+++ b/crates/fetchkit/src/fetchers/jupyter_notebook.rs
@@ -3,7 +3,7 @@
 use crate::client::FetchOptions;
 use crate::error::FetchError;
 use crate::fetchers::default::{read_full_body, transport_request};
-use crate::fetchers::Fetcher;
+use crate::fetchers::{validate_url_policy, Fetcher};
 use crate::types::{FetchRequest, FetchResponse};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
@@ -83,7 +83,7 @@ impl Fetcher for JupyterNotebookFetcher {
         let page_url = Url::parse(&request.url).map_err(|_| FetchError::InvalidUrlScheme)?;
         let (raw_url, host) = Self::raw_url(&page_url)
             .ok_or_else(|| FetchError::FetcherError("Not a supported notebook URL".into()))?;
-        options.validate_url(&raw_url)?;
+        validate_url_policy(&raw_url, options)?;
         let mut headers = HeaderMap::new();
         headers.insert(
             USER_AGENT,


### PR DESCRIPTION
### Motivation
- Jupyter notebook fetcher rewrites GitHub/GitLab blob URLs to raw-content URLs and then executed the outbound request without re-applying fetch policy, allowing blocked hosts or port restrictions to be bypassed. 
- Enforce the same host/port allow/block rules on the rewritten raw destination to close this egress-policy gap.

### Description
- Call `options.validate_url(&raw_url)?;` in `JupyterNotebookFetcher::fetch` before calling `transport_request` so the rewritten raw-content URL is validated against `blocked_hosts` and `allowed_ports` policies.  
- Add regression tests in `crates/fetchkit/src/fetchers/jupyter_notebook.rs` that inject a `CountingTransport` to assert the transport is not invoked when the rewritten raw host is blocked or the rewritten port is disallowed.  
- Change is minimal and tightens validation only for notebook raw-content requests without altering successful fetch behavior.

### Testing
- Ran the new unit tests for the notebook fetcher with `cargo test -p fetchkit jupyter_notebook::tests -- --nocapture` and they passed.  
- Ran the full test suite with `cargo test --workspace` and all tests passed.  
- Verified `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, and `cargo build --workspace --exclude fetchkit-python --release` all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5baab2eb28832b971e8b7cf36773aa)