### PR TITLE
chore(ship): prompt for PR evidence in the ship skill

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -114,7 +114,8 @@ gh pr view --json url 2>/dev/null
 If no PR exists, create one:
 
 - Title: conventional commit style from the branch changes
-- Body: use What / Why / How / Risk / Checklist
+- Body: use `.github/pull_request_template.md` (What changed / Why / Before / After / Risk / Checklist); center it on functional change and impact, not a code-location walkthrough
+- Evidence: in the Before / After, attach proof — CLI/API output or logs (fetch results, MCP responses). Say so when there is no observable behavior change
 - Never add AI attribution or session links
 
 If a PR exists, update it if needed and report its URL.


### PR DESCRIPTION
## What changed

The `/ship` command's Push-and-PR phase now prompts for **evidence in the PR body** — a Before / After with proof: CLI/API output or logs (fetch results, MCP responses). The Body line is also updated to reference `.github/pull_request_template.md` with the current sections (What changed / Why / Before / After / Risk / Checklist) and to center the description on functional change and impact.

## Why

The ship flow already gathers validation, but the command didn't tell the agent to attach that proof to the PR, and its body reference still listed the old What/Why/How sections. Reviewers benefit from seeing the change work, not reading that it does.

## Before / After

Docs/skill-guidance only — no runtime behavior changes.

- **Before:** Body step said "use What / Why / How / Risk / Checklist."
- **After:** references the PR template (What changed / Why / Before / After / Risk / Checklist) + functional framing, and adds an Evidence line (CLI/API output or logs), noting when there's no observable change.

## Risk

- Low
- Skill/docs only; no source, config, or CI logic touched.

## Checklist

- [x] Unit tests are passed — N/A (skill/docs only)
- [x] Smoke tests are passed — N/A
- [x] Documentation is updated
- [x] Specs are up to date and not in conflict

---
_Generated by [Claude Code](https://claude.ai/code/session_013LSB82Db25Rf3tVPqWb1JQ)_