### PR TITLE
feat(convert)!: add pluggable HTML content processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replace the specification directory with an indexed OKF v0.2 knowledge
   bundle, maintenance contract, update log, and CI conformance checks.
+- Route HTML extraction and Markdown/text conversion through the pluggable
+  `ContentProcessor` registry with a built-in `HtmlProcessor` and replaceable
+  `HtmlToMarkdownConverter`.
+- Preserve richer HTML semantics in Markdown, including collision-safe code
+  fences, footnotes, math, callouts, highlights, strikethrough, image sources,
+  figure captions, task checkboxes, and valid tables with formatted cells.
 - Add a pluggable post-download `ContentProcessor` registry and built-in
   `PdfProcessor` that extracts Markdown from text-based PDFs with local
   `pdf-inspector` processing and explicit OCR guidance for unsupported pages.
@@ -18,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   conventional probes, including `llms.txt`, `auth.md`, OAuth metadata, MCP
   server cards, A2A agent cards, and Agent Skills indexes. Markdown responses
   include a compact navigation appendix.
+
+### Changed
+
+- `ContentProcessorInput` now includes the requested output format and HTML
+  content focus. Custom processors constructing this public input must populate
+  the new fields.
 
 ## [0.5.0] - 2026-07-14
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ fetchers match first; the default fetcher handles everything else.
 ## Built-in Content Processors
 
 Content processors run after a fetcher retrieves a bounded response body. They
-select by final URL and response media type, then turn non-text formats into
-LLM-friendly content without performing their own network requests.
+select by final URL, response media type, and requested output, then turn
+documents into LLM-friendly content without performing their own network
+requests.
 
+- `HtmlProcessor` - metadata and focused-content extraction followed by native
+  Markdown or text conversion; accepts a custom `HtmlToMarkdownConverter`
 - `PdfProcessor` - text-based PDF classification and Markdown extraction via
   [`pdf-inspector`](https://github.com/firecrawl/pdf-inspector); scanned or
   image-only pages are reported as requiring OCR
@@ -346,12 +349,15 @@ Other binary content returns metadata only:
 HTML is automatically converted to markdown:
 - Headers: `h1-h6` → `#` to `######`
 - Lists: Proper nesting with 2-space indent
-- Code: Fenced blocks and inline backticks
-- Links: `[text](url)` format
-- Strips: scripts, styles, iframes, SVGs
+- Code: Language-aware, collision-safe fences and inline backticks
+- Links/images: Titles, relative-URL resolution, and highest-resolution `srcset`
+- Tables: Valid Markdown with formatted cells and escaped pipes
+- Rich content: Footnotes, LaTeX math, callouts, figures, highlights,
+  strikethrough, details, and task checkboxes
+- Strips: document head, scripts, styles, templates, iframes, SVGs
 - Adds a bounded [Agent resources](docs/agent-discoverability.md) navigation appendix
   when discoverable resources are available
 
 ## License
 
-MIT
+MIT. See [Third-Party Notices](THIRD_PARTY_NOTICES.md) for adapted components.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,28 @@
+# Third-Party Notices
+
+## Defuddle
+
+Fetchkit's HTML-to-Markdown conversion behavior includes portions adapted from
+[Defuddle](https://github.com/kepano/defuddle).
+
+MIT License
+
+Copyright (c) 2025 Steph Ango (@kepano)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/fetchkit/src/content.rs
+++ b/crates/fetchkit/src/content.rs
@@ -10,6 +10,10 @@ use thiserror::Error;
 use tokio::sync::Semaphore;
 use url::Url;
 
+use crate::convert::{
+    extract_headings, extract_metadata, extract_readable_content, filter_excessive_newlines,
+    html_to_text, strip_boilerplate, BuiltinHtmlToMarkdownConverter, HtmlToMarkdownConverter,
+};
 use crate::{PageMetadata, PageQuality};
 
 // pdf-inspector uses Rayon internally; bound concurrent documents so batch fetches
@@ -24,6 +28,48 @@ pub struct ContentProcessorInput {
     pub content_type: Option<String>,
     /// Response body after fetchkit's timeout and size limits were applied.
     pub body: Bytes,
+    /// Requested textual representation.
+    pub output_format: ContentOutputFormat,
+    /// HTML content-selection strategy.
+    pub content_focus: ContentFocus,
+}
+
+/// Requested representation produced by a content processor.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ContentOutputFormat {
+    /// LLM-oriented Markdown.
+    #[default]
+    Markdown,
+    /// Plain text.
+    Text,
+    /// Focused HTML without Markdown/text serialization.
+    Raw,
+}
+
+/// HTML content-selection strategy applied before conversion.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ContentFocus {
+    /// Preserve the complete document body.
+    #[default]
+    Full,
+    /// Prefer semantic `<main>` or `<article>` content.
+    Main,
+    /// Select the densest readable content candidate.
+    Readable,
+    /// Select readable content with a semantic-main fallback for agents.
+    Agent,
+}
+
+impl ContentFocus {
+    /// Parse the public request spelling, treating unknown values as `full`.
+    pub fn from_request(value: Option<&str>) -> Self {
+        match value {
+            Some(value) if value.eq_ignore_ascii_case("main") => Self::Main,
+            Some(value) if value.eq_ignore_ascii_case("readable") => Self::Readable,
+            Some(value) if value.eq_ignore_ascii_case("agent") => Self::Agent,
+            _ => Self::Full,
+        }
+    }
 }
 
 /// Content extracted from a non-text response.
@@ -58,6 +104,16 @@ pub trait ContentProcessor: Send + Sync {
     /// rejected as binary, so implementations must not inspect body bytes here.
     fn matches(&self, url: &Url, content_type: Option<&str>) -> bool;
 
+    /// Whether this processor can produce the requested representation.
+    fn supports_output(&self, output_format: ContentOutputFormat) -> bool {
+        output_format == ContentOutputFormat::Markdown
+    }
+
+    /// Whether bounded partial input remains useful to this processor.
+    fn accepts_truncated_input(&self) -> bool {
+        false
+    }
+
     /// Process an already-downloaded, bounded response body.
     async fn process(
         &self,
@@ -88,6 +144,7 @@ impl ContentProcessorRegistry {
     pub fn with_defaults() -> Self {
         let mut registry = Self::new();
         registry.register(Box::new(PdfProcessor));
+        registry.register(Box::new(HtmlProcessor::default()));
         registry
     }
 
@@ -96,12 +153,115 @@ impl ContentProcessorRegistry {
         self.processors.push(processor);
     }
 
+    pub(crate) fn contains_named(&self, name: &str) -> bool {
+        self.processors
+            .iter()
+            .any(|processor| processor.name() == name)
+    }
+
     /// Find the first processor matching response metadata.
     pub fn find(&self, url: &Url, content_type: Option<&str>) -> Option<&dyn ContentProcessor> {
         self.processors
             .iter()
             .find(|processor| processor.matches(url, content_type))
             .map(Box::as_ref)
+    }
+
+    /// Find the first matching processor that supports the requested output.
+    pub fn find_for_output(
+        &self,
+        url: &Url,
+        content_type: Option<&str>,
+        output_format: ContentOutputFormat,
+    ) -> Option<&dyn ContentProcessor> {
+        self.processors
+            .iter()
+            .find(|processor| {
+                processor.matches(url, content_type) && processor.supports_output(output_format)
+            })
+            .map(Box::as_ref)
+    }
+}
+
+/// Extracts and converts bounded HTML documents.
+pub struct HtmlProcessor {
+    markdown_converter: Box<dyn HtmlToMarkdownConverter>,
+}
+
+impl Default for HtmlProcessor {
+    fn default() -> Self {
+        Self::new(Box::<BuiltinHtmlToMarkdownConverter>::default())
+    }
+}
+
+impl HtmlProcessor {
+    /// Create an HTML processor using a caller-supplied Markdown converter.
+    pub fn new(markdown_converter: Box<dyn HtmlToMarkdownConverter>) -> Self {
+        Self { markdown_converter }
+    }
+}
+
+#[async_trait]
+impl ContentProcessor for HtmlProcessor {
+    fn name(&self) -> &'static str {
+        "html"
+    }
+
+    fn matches(&self, _url: &Url, content_type: Option<&str>) -> bool {
+        content_type
+            .and_then(|value| value.split(';').next())
+            .map(str::trim)
+            .is_some_and(|media_type| {
+                media_type.eq_ignore_ascii_case("text/html")
+                    || media_type.eq_ignore_ascii_case("application/xhtml+xml")
+            })
+    }
+
+    fn supports_output(&self, _output_format: ContentOutputFormat) -> bool {
+        true
+    }
+
+    fn accepts_truncated_input(&self) -> bool {
+        true
+    }
+
+    async fn process(
+        &self,
+        input: ContentProcessorInput,
+    ) -> Result<ProcessedContent, ContentProcessorError> {
+        let html = String::from_utf8_lossy(&input.body).into_owned();
+        let mut metadata = extract_metadata(&html);
+        metadata.headings = extract_headings(&html);
+
+        let (focused_html, extraction_method) = match input.content_focus {
+            ContentFocus::Full => (html, "full"),
+            ContentFocus::Main => (strip_boilerplate(&html), "main"),
+            ContentFocus::Readable => match extract_readable_content(&html) {
+                Some(readable) => (readable, "readable"),
+                None => (strip_boilerplate(&html), "readable_fallback_main"),
+            },
+            ContentFocus::Agent => match extract_readable_content(&html) {
+                Some(readable) => (readable, "agent_readable"),
+                None => (strip_boilerplate(&html), "agent_main"),
+            },
+        };
+
+        let (format, content) = match input.output_format {
+            ContentOutputFormat::Markdown => (
+                "markdown",
+                self.markdown_converter.convert(&focused_html, &input.url),
+            ),
+            ContentOutputFormat::Text => ("text", html_to_text(&focused_html)),
+            ContentOutputFormat::Raw => ("raw", focused_html),
+        };
+        metadata.extraction_method = Some(extraction_method.to_string());
+
+        Ok(ProcessedContent {
+            format: Some(format.to_string()),
+            content: Some(filter_excessive_newlines(&content)),
+            metadata: (!metadata.is_empty()).then_some(metadata),
+            ..Default::default()
+        })
     }
 }
 
@@ -202,6 +362,14 @@ fn comma_separated_pages(pages: &[u32]) -> String {
 mod tests {
     use super::*;
 
+    struct StubMarkdownConverter;
+
+    impl HtmlToMarkdownConverter for StubMarkdownConverter {
+        fn convert(&self, _html: &str, base_url: &Url) -> String {
+            format!("converted by stub for {base_url}")
+        }
+    }
+
     fn text_pdf(text: &str) -> Bytes {
         let escaped = text
             .replace('\\', "\\\\")
@@ -261,7 +429,85 @@ mod tests {
                 .map(ContentProcessor::name),
             Some("pdf")
         );
+        assert_eq!(
+            registry
+                .find_for_output(
+                    &url,
+                    Some("text/html; charset=utf-8"),
+                    ContentOutputFormat::Text,
+                )
+                .map(ContentProcessor::name),
+            Some("html")
+        );
         assert!(registry.find(&url, Some("image/png")).is_none());
+    }
+
+    #[tokio::test]
+    async fn html_processor_extracts_focused_markdown() {
+        let processor = HtmlProcessor::default();
+        let result = processor
+            .process(ContentProcessorInput {
+                url: Url::parse("https://example.com/article").unwrap(),
+                content_type: Some("text/html".to_string()),
+                body: Bytes::from_static(
+                    br#"<html><head><title>Example</title></head><body><nav>Menu</nav><main><h1>Article</h1><p>Useful text.</p></main></body></html>"#,
+                ),
+                output_format: ContentOutputFormat::Markdown,
+                content_focus: ContentFocus::Main,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.format.as_deref(), Some("markdown"));
+        assert!(result.content.as_deref().unwrap().contains("# Article"));
+        assert!(!result.content.as_deref().unwrap().contains("Menu"));
+        assert_eq!(
+            result.metadata.unwrap().extraction_method.as_deref(),
+            Some("main")
+        );
+    }
+
+    #[tokio::test]
+    async fn html_processor_preserves_focused_raw_html() {
+        let processor = HtmlProcessor::default();
+        let result = processor
+            .process(ContentProcessorInput {
+                url: Url::parse("https://example.com/article").unwrap(),
+                content_type: Some("text/html".to_string()),
+                body: Bytes::from_static(
+                    br#"<nav>Menu</nav><main><p>Useful <strong>HTML</strong>.</p></main>"#,
+                ),
+                output_format: ContentOutputFormat::Raw,
+                content_focus: ContentFocus::Main,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.format.as_deref(), Some("raw"));
+        assert_eq!(
+            result.content.as_deref(),
+            Some("<p>Useful <strong>HTML</strong>.</p>")
+        );
+    }
+
+    #[tokio::test]
+    async fn html_processor_accepts_custom_markdown_converter() {
+        let processor = HtmlProcessor::new(Box::new(StubMarkdownConverter));
+        let result = processor
+            .process(ContentProcessorInput {
+                url: Url::parse("https://example.com/article").unwrap(),
+                content_type: Some("text/html".to_string()),
+                body: Bytes::from_static(b"<p>Ignored by stub</p>"),
+                output_format: ContentOutputFormat::Markdown,
+                content_focus: ContentFocus::Full,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.content.as_deref(),
+            Some("converted by stub for https://example.com/article")
+        );
     }
 
     #[tokio::test]
@@ -272,6 +518,8 @@ mod tests {
                 url: Url::parse("https://example.com/document").unwrap(),
                 content_type: Some("application/pdf".to_string()),
                 body: text_pdf("Hello from PDF"),
+                output_format: ContentOutputFormat::Markdown,
+                content_focus: ContentFocus::Full,
             })
             .await
             .unwrap();

--- a/crates/fetchkit/src/convert.rs
+++ b/crates/fetchkit/src/convert.rs
@@ -1,7 +1,28 @@
+// Decisions:
+// - Rich HTML-to-Markdown behavior is ported and adapted from Defuddle
+//   (Copyright (c) 2025 Steph Ango, MIT): https://github.com/kepano/defuddle
+// - Fetchkit's established behavior wins on conflicts; keep the implementation native
+//   and dependency-light rather than embedding a JavaScript runtime.
 //! HTML conversion utilities
 
 use crate::types::{AgentResource, PageLink, PageMetadata};
 use url::Url;
+
+/// Converts HTML into Markdown independently of retrieval and content extraction.
+pub trait HtmlToMarkdownConverter: Send + Sync {
+    /// Convert HTML while resolving relative navigation against `base_url`.
+    fn convert(&self, html: &str, base_url: &Url) -> String;
+}
+
+/// Fetchkit's built-in native HTML-to-Markdown converter.
+#[derive(Debug, Default)]
+pub struct BuiltinHtmlToMarkdownConverter;
+
+impl HtmlToMarkdownConverter for BuiltinHtmlToMarkdownConverter {
+    fn convert(&self, html: &str, base_url: &Url) -> String {
+        html_to_markdown_inner(html, Some(base_url))
+    }
+}
 
 /// Check if content-type indicates markdown (e.g. `text/markdown`).
 pub fn is_markdown_content_type(content_type: &Option<String>) -> bool {
@@ -68,15 +89,32 @@ pub fn html_to_markdown_with_base_url(html: &str, base_url: &str) -> String {
 }
 
 fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
+    html_to_markdown_at_depth(html, base_url, 0)
+}
+
+const MAX_MARKDOWN_CONVERSION_DEPTH: usize = 8;
+
+fn html_to_markdown_at_depth(html: &str, base_url: Option<&Url>, depth: usize) -> String {
+    if depth >= MAX_MARKDOWN_CONVERSION_DEPTH {
+        return html_to_text(html);
+    }
     let mut output = String::new();
     let mut in_skip_element = 0;
     let mut skip_elements: Vec<String> = Vec::new();
     let mut in_pre = false;
+    let mut pre_buffer = String::new();
+    let mut pre_language = None;
+    let mut inline_code_buffer: Option<String> = None;
     let mut in_blockquote = false;
+    let mut footnote_reference = false;
+    let mut skip_backlink = false;
+    let mut math_capture: Option<MathCapture> = None;
+    let mut callout_capture: Option<CalloutCapture> = None;
 
     // Link tracking: when we see <a href="...">, save href and record the output
     // position. On </a>, wrap the text collected since then in [text](href).
     let mut link_href: Option<String> = None;
+    let mut link_title: Option<String> = None;
     let mut link_start: usize = 0;
 
     // List tracking: stack of list types (true=ordered, false=unordered) with item counter
@@ -88,7 +126,6 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
     let mut current_row: Vec<String> = Vec::new();
     let mut in_cell = false;
     let mut cell_buf = String::new();
-    let mut is_header_row = false;
 
     let mut chars = html.chars().peekable();
 
@@ -113,7 +150,9 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
             };
 
             // THREAT[TM-CONV-001]: Strip script/style/iframe/svg to prevent injection
-            let skip_tags = ["script", "style", "noscript", "iframe", "svg"];
+            let skip_tags = [
+                "head", "script", "style", "noscript", "iframe", "svg", "template",
+            ];
             if skip_tags.contains(&tag_name) {
                 if is_closing {
                     if let Some(pos) = skip_elements.iter().rposition(|t| t == tag_name) {
@@ -128,6 +167,134 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
             }
 
             if in_skip_element > 0 {
+                continue;
+            }
+
+            if let Some(capture) = &mut callout_capture {
+                if !is_closing && tag_name == capture.root_tag {
+                    capture.depth += 1;
+                } else if is_closing && tag_name == capture.root_tag {
+                    capture.depth = capture.depth.saturating_sub(1);
+                    if capture.depth == 0 {
+                        let capture = callout_capture.take().expect("callout capture exists");
+                        output.push_str(&render_callout(capture, base_url, depth));
+                        continue;
+                    }
+                }
+                capture.html.push('<');
+                capture.html.push_str(&tag);
+                capture.html.push('>');
+                continue;
+            }
+
+            if !is_closing {
+                let class = extract_attribute(&tag, "class").unwrap_or_default();
+                if class
+                    .split_ascii_whitespace()
+                    .any(|value| value == "callout")
+                {
+                    if let Some(kind) = extract_attribute(&tag, "data-callout") {
+                        callout_capture = Some(CalloutCapture {
+                            root_tag: tag_name.to_string(),
+                            depth: 1,
+                            kind,
+                            fold: extract_attribute(&tag, "data-callout-fold"),
+                            html: String::new(),
+                        });
+                        continue;
+                    }
+                }
+            }
+
+            if let Some(capture) = &mut math_capture {
+                if !is_closing && tag_name == capture.root_tag {
+                    capture.depth += 1;
+                } else if is_closing && tag_name == capture.root_tag {
+                    capture.depth = capture.depth.saturating_sub(1);
+                }
+                if tag_name == "annotation" {
+                    if is_closing {
+                        capture.in_annotation = false;
+                    } else if extract_attribute(&tag, "encoding")
+                        .is_some_and(|value| value.eq_ignore_ascii_case("application/x-tex"))
+                    {
+                        capture.in_annotation = true;
+                    }
+                }
+                if capture.depth == 0 {
+                    let capture = math_capture.take().expect("math capture exists");
+                    output.push_str(&render_math(capture));
+                }
+                continue;
+            }
+
+            let class = (!is_closing)
+                .then(|| extract_attribute(&tag, "class"))
+                .flatten()
+                .unwrap_or_default();
+            let is_katex = class
+                .split_ascii_whitespace()
+                .any(|value| value == "katex" || value == "math");
+            if !is_closing && (tag_name == "math" || is_katex) {
+                math_capture = Some(MathCapture {
+                    root_tag: tag_name.to_string(),
+                    depth: 1,
+                    latex: extract_attribute(&tag, "data-latex")
+                        .or_else(|| extract_attribute(&tag, "alttext"))
+                        .unwrap_or_default(),
+                    annotation: String::new(),
+                    text: String::new(),
+                    in_annotation: false,
+                    display: extract_attribute(&tag, "display")
+                        .is_some_and(|value| value.eq_ignore_ascii_case("block"))
+                        || class.split_ascii_whitespace().any(|value| {
+                            matches!(value, "katex-display" | "math-display" | "display-math")
+                        }),
+                });
+                continue;
+            }
+
+            if in_pre {
+                if tag_name == "pre" && is_closing {
+                    output.push_str(&render_fenced_code(&pre_buffer, pre_language.as_deref()));
+                    pre_buffer.clear();
+                    pre_language = None;
+                    in_pre = false;
+                } else if tag_name == "code" && !is_closing {
+                    pre_language = extract_code_language(&tag).or(pre_language);
+                } else if tag_name == "br" {
+                    pre_buffer.push('\n');
+                }
+                continue;
+            }
+
+            if let Some(code) = &mut inline_code_buffer {
+                if tag_name == "code" && is_closing {
+                    let code = std::mem::take(code);
+                    inline_code_buffer = None;
+                    output.push_str(&render_inline_code(&code));
+                }
+                continue;
+            }
+
+            if footnote_reference {
+                if tag_name == "sup" && is_closing {
+                    footnote_reference = false;
+                }
+                continue;
+            }
+
+            if skip_backlink {
+                if tag_name == "a" && is_closing {
+                    skip_backlink = false;
+                }
+                continue;
+            }
+
+            if in_cell && !matches!(tag_name, "th" | "td") {
+                cell_buf.push('<');
+                cell_buf.push_str(&tag);
+                cell_buf.push('>');
                 continue;
             }
 
@@ -178,6 +345,12 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
                 }
                 "li" if !is_closing => {
                     output.push('\n');
+                    if let Some(id) = extract_attribute(&tag, "id")
+                        .and_then(|id| id.strip_prefix("fn:").map(str::to_string))
+                    {
+                        output.push_str(&format!("[^{id}]: "));
+                        continue;
+                    }
                     let depth = list_stack.len().saturating_sub(1);
                     for _ in 0..depth {
                         output.push_str("  ");
@@ -199,20 +372,23 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
                 "em" | "i" => {
                     output.push('*');
                 }
+                "del" | "s" | "strike" => {
+                    output.push_str("~~");
+                }
+                "mark" => {
+                    output.push_str("==");
+                }
                 "pre" => {
                     if !is_closing {
-                        let language = extract_code_language(&tag);
-                        output.push_str("\n```");
-                        output.push_str(language.as_deref().unwrap_or_default());
-                        output.push('\n');
+                        pre_buffer.clear();
+                        pre_language = extract_code_language(&tag);
                         in_pre = true;
-                    } else {
-                        output.push_str("\n```\n");
-                        in_pre = false;
                     }
                 }
-                "code" if !in_pre => {
-                    output.push('`');
+                "code" => {
+                    if !is_closing {
+                        inline_code_buffer = Some(String::new());
+                    }
                 }
                 "blockquote" => {
                     if !is_closing {
@@ -226,8 +402,11 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
                 "a" => {
                     if !is_closing {
                         if let Some(href) = extract_attribute(&tag, "href") {
-                            if !href.is_empty() {
+                            if href.starts_with("#fnref") {
+                                skip_backlink = true;
+                            } else if !href.is_empty() {
                                 link_href = Some(resolve_url(base_url, &href));
+                                link_title = extract_attribute(&tag, "title");
                                 link_start = output.len();
                             }
                         }
@@ -237,14 +416,52 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
                         if text.is_empty() {
                             output.push_str(&format!("<{}>", href));
                         } else {
-                            output.push_str(&format!("[{}]({})", text, href));
+                            output.push_str(&format_markdown_link(
+                                &text,
+                                &href,
+                                link_title.take().as_deref(),
+                            ));
                         }
                     }
                 }
                 "img" if !is_closing => {
                     let alt = extract_attribute(&tag, "alt").unwrap_or_default();
-                    if let Some(src) = extract_attribute(&tag, "src") {
-                        output.push_str(&format!("![{}]({})", alt, resolve_url(base_url, &src)));
+                    if let Some(src) = best_image_source(&tag) {
+                        output.push('!');
+                        output.push_str(&format_markdown_link(
+                            &alt,
+                            &resolve_url(base_url, &src),
+                            extract_attribute(&tag, "title").as_deref(),
+                        ));
+                    }
+                }
+                "input" if !is_closing => {
+                    if extract_attribute(&tag, "type")
+                        .is_some_and(|value| value.eq_ignore_ascii_case("checkbox"))
+                    {
+                        let checked = extract_attribute(&tag, "checked").is_some()
+                            || tag
+                                .split_ascii_whitespace()
+                                .any(|value| value.eq_ignore_ascii_case("checked"));
+                        output.push_str(if checked { "[x] " } else { "[ ] " });
+                    }
+                }
+                "figure" | "figcaption" | "details" => {
+                    output.push_str("\n\n");
+                }
+                "summary" => {
+                    if is_closing {
+                        output.push_str("**\n\n");
+                    } else {
+                        output.push_str("\n**");
+                    }
+                }
+                "sup" if !is_closing => {
+                    if let Some(id) = extract_attribute(&tag, "id")
+                        .and_then(|id| id.strip_prefix("fnref:").map(str::to_string))
+                    {
+                        output.push_str(&format!("[^{id}]"));
+                        footnote_reference = true;
                     }
                 }
                 // Table handling
@@ -261,14 +478,8 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
                 "tr" => {
                     if !is_closing {
                         current_row.clear();
-                        is_header_row = false;
                     } else if in_table {
                         table_rows.push(current_row.clone());
-                        if is_header_row && table_rows.len() == 1 {
-                            let sep: Vec<String> =
-                                current_row.iter().map(|_| "---".to_string()).collect();
-                            table_rows.push(sep);
-                        }
                         current_row.clear();
                     }
                 }
@@ -276,10 +487,9 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
                     if !is_closing {
                         in_cell = true;
                         cell_buf.clear();
-                        is_header_row = true;
                     } else {
                         in_cell = false;
-                        current_row.push(cell_buf.trim().to_string());
+                        current_row.push(render_table_cell(&cell_buf, base_url, depth));
                         cell_buf.clear();
                     }
                 }
@@ -289,7 +499,7 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
                         cell_buf.clear();
                     } else {
                         in_cell = false;
-                        current_row.push(cell_buf.trim().to_string());
+                        current_row.push(render_table_cell(&cell_buf, base_url, depth));
                         cell_buf.clear();
                     }
                 }
@@ -317,7 +527,20 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
             // Text content
             let decoded = decode_entity(c, &mut chars);
 
-            if in_cell {
+            if let Some(capture) = &mut callout_capture {
+                capture.html.push(decoded);
+            } else if let Some(capture) = &mut math_capture {
+                capture.text.push(decoded);
+                if capture.in_annotation {
+                    capture.annotation.push(decoded);
+                }
+            } else if in_pre {
+                pre_buffer.push(decoded);
+            } else if let Some(code) = &mut inline_code_buffer {
+                code.push(decoded);
+            } else if footnote_reference || skip_backlink {
+                continue;
+            } else if in_cell {
                 cell_buf.push(decoded);
             } else if in_table {
                 // Ignore text outside cells but inside table
@@ -329,7 +552,249 @@ fn html_to_markdown_inner(html: &str, base_url: Option<&Url>) -> String {
         }
     }
 
-    clean_whitespace(&output)
+    if let Some(capture) = callout_capture {
+        output.push_str(&render_callout(capture, base_url, depth));
+    }
+    if let Some(capture) = math_capture {
+        output.push_str(&render_math(capture));
+    }
+    if in_pre {
+        output.push_str(&render_fenced_code(&pre_buffer, pre_language.as_deref()));
+    }
+    if let Some(code) = inline_code_buffer {
+        output.push_str(&render_inline_code(&code));
+    }
+
+    clean_markdown_whitespace(&output)
+}
+
+fn clean_markdown_whitespace(markdown: &str) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    let mut fence_length = None;
+
+    for line in markdown.lines() {
+        let trimmed = line.trim_start();
+        let backticks = trimmed
+            .chars()
+            .take_while(|character| *character == '`')
+            .count();
+        let opens_fence = fence_length.is_none() && backticks >= 3;
+        let closes_fence = fence_length
+            .is_some_and(|length| backticks >= length && trimmed[backticks..].trim().is_empty());
+        let preserve = fence_length.is_some() || opens_fence;
+        let line = if preserve {
+            line.trim_end().to_string()
+        } else {
+            collapse_markdown_line(line)
+        };
+
+        if preserve || !line.is_empty() || lines.last().is_some_and(|line| !line.is_empty()) {
+            lines.push(line);
+        }
+        if opens_fence {
+            fence_length = Some(backticks);
+        } else if closes_fence {
+            fence_length = None;
+        }
+    }
+
+    while lines.first().is_some_and(String::is_empty) {
+        lines.remove(0);
+    }
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+    lines.join("\n")
+}
+
+fn collapse_markdown_line(line: &str) -> String {
+    let characters: Vec<char> = line.chars().collect();
+    let mut output = String::new();
+    let mut inline_delimiter = None;
+    let mut pending_space = false;
+    let mut seen_nonwhitespace = false;
+    let mut index = 0;
+
+    while index < characters.len() {
+        if characters[index] == '`' {
+            if pending_space {
+                output.push(' ');
+                pending_space = false;
+            }
+            let start = index;
+            while index < characters.len() && characters[index] == '`' {
+                output.push('`');
+                index += 1;
+            }
+            let run = index - start;
+            seen_nonwhitespace = true;
+            inline_delimiter = match inline_delimiter {
+                Some(length) if length == run => None,
+                Some(length) => Some(length),
+                None => Some(run),
+            };
+            continue;
+        }
+
+        let character = characters[index];
+        if character.is_whitespace() {
+            if inline_delimiter.is_some() || !seen_nonwhitespace {
+                output.push(character);
+            } else {
+                pending_space = true;
+            }
+        } else {
+            if pending_space {
+                output.push(' ');
+                pending_space = false;
+            }
+            output.push(character);
+            seen_nonwhitespace = true;
+        }
+        index += 1;
+    }
+
+    output.trim_end().to_string()
+}
+
+struct MathCapture {
+    root_tag: String,
+    depth: usize,
+    latex: String,
+    annotation: String,
+    text: String,
+    in_annotation: bool,
+    display: bool,
+}
+
+struct CalloutCapture {
+    root_tag: String,
+    depth: usize,
+    kind: String,
+    fold: Option<String>,
+    html: String,
+}
+
+fn render_callout(capture: CalloutCapture, base_url: Option<&Url>, depth: usize) -> String {
+    let content = html_to_markdown_at_depth(&capture.html, base_url, depth + 1);
+    let fold = capture
+        .fold
+        .filter(|value| matches!(value.as_str(), "+" | "-"))
+        .unwrap_or_default();
+    let mut output = format!("\n\n> [!{}]{fold}", capture.kind);
+    for line in content.lines() {
+        output.push('\n');
+        output.push_str("> ");
+        output.push_str(line);
+    }
+    output.push_str("\n\n");
+    output
+}
+
+fn render_math(capture: MathCapture) -> String {
+    let latex = if !capture.annotation.trim().is_empty() {
+        capture.annotation.trim()
+    } else if !capture.latex.trim().is_empty() {
+        capture.latex.trim()
+    } else {
+        capture.text.trim()
+    };
+    if latex.is_empty() {
+        return String::new();
+    }
+    if capture.display {
+        format!("\n\n$$\n{latex}\n$$\n\n")
+    } else {
+        format!("${latex}$")
+    }
+}
+
+fn render_fenced_code(code: &str, language: Option<&str>) -> String {
+    let code = code.trim_matches('\n');
+    let fence = "`".repeat(max_backtick_run(code).saturating_add(1).max(3));
+    format!(
+        "\n{fence}{}\n{code}\n{fence}\n",
+        language.unwrap_or_default()
+    )
+}
+
+fn render_inline_code(code: &str) -> String {
+    let delimiter = "`".repeat(max_backtick_run(code).saturating_add(1).max(1));
+    let needs_padding = code.starts_with(['`', ' ']) || code.ends_with(['`', ' ']);
+    if needs_padding {
+        format!("{delimiter} {code} {delimiter}")
+    } else {
+        format!("{delimiter}{code}{delimiter}")
+    }
+}
+
+fn max_backtick_run(value: &str) -> usize {
+    value
+        .split(|character| character != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0)
+}
+
+fn format_markdown_link(text: &str, destination: &str, title: Option<&str>) -> String {
+    let text = if text.contains("](") {
+        text.to_string()
+    } else {
+        text.replace('\\', "\\\\")
+            .replace('[', "\\[")
+            .replace(']', "\\]")
+    };
+    let destination = if destination.contains([' ', '(', ')']) {
+        format!("<{}>", destination.replace('>', "%3E"))
+    } else {
+        destination.to_string()
+    };
+    let title = title
+        .filter(|title| !title.is_empty())
+        .map(|title| format!(" \"{}\"", title.replace('"', "\\\"")))
+        .unwrap_or_default();
+    format!("[{text}]({destination}{title})")
+}
+
+fn best_image_source(tag: &str) -> Option<String> {
+    let fallback = extract_attribute(tag, "src");
+    let Some(srcset) = extract_attribute(tag, "srcset") else {
+        return fallback;
+    };
+    srcset
+        .split(',')
+        .filter_map(|candidate| {
+            let mut parts = candidate.split_whitespace();
+            let url = parts.next()?.to_string();
+            let score = parts
+                .next()
+                .and_then(|descriptor| {
+                    descriptor
+                        .strip_suffix('w')
+                        .and_then(|value| value.parse::<f64>().ok())
+                        .or_else(|| {
+                            descriptor
+                                .strip_suffix('x')
+                                .and_then(|value| value.parse::<f64>().ok())
+                                .map(|density| density * 1_000.0)
+                        })
+                })
+                .unwrap_or_default();
+            Some((url, score))
+        })
+        .max_by(|left, right| left.1.total_cmp(&right.1))
+        .map(|(url, _)| url)
+        .or(fallback)
+}
+
+fn render_table_cell(html: &str, base_url: Option<&Url>, depth: usize) -> String {
+    html_to_markdown_at_depth(html, base_url, depth + 1)
+        .replace('|', "\\|")
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("<br>")
 }
 
 fn resolve_url(base_url: Option<&Url>, candidate: &str) -> String {
@@ -372,11 +837,29 @@ fn render_table(rows: &[Vec<String>], output: &mut String) {
         return;
     }
 
+    let width = rows.iter().map(Vec::len).max().unwrap_or_default();
+    if width == 0 {
+        return;
+    }
+    let has_separator = rows.get(1).is_some_and(|row| {
+        row.len() == width && row.iter().all(|cell| cell.trim_matches(':') == "---")
+    });
+
     output.push('\n');
-    for row in rows {
+    for (index, row) in rows.iter().enumerate() {
         output.push_str("| ");
-        output.push_str(&row.join(" | "));
+        for column in 0..width {
+            if column > 0 {
+                output.push_str(" | ");
+            }
+            output.push_str(row.get(column).map(String::as_str).unwrap_or_default());
+        }
         output.push_str(" |\n");
+        if index == 0 && !has_separator {
+            output.push_str("| ");
+            output.push_str(&vec!["---"; width].join(" | "));
+            output.push_str(" |\n");
+        }
     }
 }
 
@@ -423,7 +906,9 @@ pub fn html_to_text(html: &str) -> String {
             };
 
             // THREAT[TM-CONV-001]: Strip script/style/iframe/svg to prevent injection
-            let skip_tags = ["script", "style", "noscript", "iframe", "svg"];
+            let skip_tags = [
+                "head", "script", "style", "noscript", "iframe", "svg", "template",
+            ];
             if skip_tags.contains(&tag_name) {
                 if is_closing {
                     if let Some(pos) = skip_elements.iter().rposition(|t| t == tag_name) {
@@ -1593,6 +2078,19 @@ mod tests {
     }
 
     #[test]
+    fn test_html_conversion_strips_head_but_metadata_keeps_title() {
+        let html = "<html><head><title>Metadata Title</title><template>Hidden</template></head><body><h1>Visible</h1></body></html>";
+        let markdown = html_to_markdown(html);
+        let text = html_to_text(html);
+        let metadata = extract_metadata(html);
+
+        assert!(!markdown.contains("Metadata Title"), "Got: {markdown}");
+        assert!(!markdown.contains("Hidden"), "Got: {markdown}");
+        assert!(!text.contains("Metadata Title"), "Got: {text}");
+        assert_eq!(metadata.title.as_deref(), Some("Metadata Title"));
+    }
+
+    #[test]
     fn test_html_to_text_simple() {
         let html = "<p>Hello</p><p>World</p>";
         let text = html_to_text(html);
@@ -2113,6 +2611,114 @@ mod tests {
     }
 
     #[test]
+    fn test_html_to_markdown_uses_collision_safe_code_fences() {
+        let html = r#"<pre><code class="language-js">const  fence = ```;
+  return fence;</code></pre>"#;
+        let md = html_to_markdown(html);
+        assert!(
+            md.contains("````js\nconst  fence = ```;\n  return fence;\n````"),
+            "Got: {md}"
+        );
+    }
+
+    #[test]
+    fn test_html_to_markdown_closes_truncated_code_fence() {
+        let md = html_to_markdown(r#"<pre class="language-rust">fn main() {"#);
+        assert!(md.contains("```rust\nfn main() {\n```"), "Got: {md}");
+    }
+
+    #[test]
+    fn test_html_to_markdown_uses_collision_safe_inline_code() {
+        let md = html_to_markdown("<p>Run <code>use  `tick`</code> now.</p>");
+        assert!(md.contains("`` use  `tick` ``"), "Got: {md}");
+    }
+
+    #[test]
+    fn test_html_to_markdown_preserves_link_and_image_titles() {
+        let html = r#"<a href="/guide" title="API guide">Read</a><img src="small.png" srcset="medium.png 600w, large.png 1200w" alt="Diagram" title="Architecture">"#;
+        let md = html_to_markdown_with_base_url(html, "https://example.com/docs/");
+        assert!(
+            md.contains(r#"[Read](https://example.com/guide "API guide")"#),
+            "Got: {md}"
+        );
+        assert!(
+            md.contains(r#"![Diagram](https://example.com/docs/large.png "Architecture")"#),
+            "Got: {md}"
+        );
+    }
+
+    #[test]
+    fn test_html_to_markdown_preserves_linked_images() {
+        let md = html_to_markdown(r#"<a href="full.png"><img src="thumb.png" alt="Preview"></a>"#);
+        assert_eq!(md, "[![Preview](thumb.png)](full.png)");
+    }
+
+    #[test]
+    fn test_html_to_markdown_preserves_rich_table_cells() {
+        let html = r#"<table><tr><th>Value</th></tr><tr><td><strong>A | B</strong><br><a href="/docs">Docs</a></td></tr></table>"#;
+        let md = html_to_markdown_with_base_url(html, "https://example.com/");
+        assert!(
+            md.contains(r#"| **A \| B**<br>[Docs](https://example.com/docs) |"#),
+            "Got: {md}"
+        );
+    }
+
+    #[test]
+    fn test_html_to_markdown_standardized_footnotes() {
+        let html = r##"<p>Claim<sup id="fnref:1"><a href="#fn:1">1</a></sup>.</p><div id="footnotes"><ol><li id="fn:1">Supporting note <a href="#fnref:1">↩</a></li></ol></div>"##;
+        let md = html_to_markdown(html);
+        assert!(md.contains("Claim[^1]."), "Got: {md}");
+        assert!(md.contains("[^1]: Supporting note"), "Got: {md}");
+        assert!(!md.contains('↩'), "Got: {md}");
+    }
+
+    #[test]
+    fn test_html_to_markdown_math_strikethrough_and_highlight() {
+        let html = r#"<p><del>old</del> <mark>important</mark> <math data-latex="a^2+b^2=c^2"></math></p><math display="block" alttext="E=mc^2"></math>"#;
+        let md = html_to_markdown(html);
+        assert!(
+            md.contains("~~old~~ ==important== $a^2+b^2=c^2$"),
+            "Got: {md}"
+        );
+        assert!(md.contains("$$\nE=mc^2\n$$"), "Got: {md}");
+    }
+
+    #[test]
+    fn test_html_to_markdown_math_uses_text_fallback() {
+        let md = html_to_markdown(r#"<span class="math">x + y</span>"#);
+        assert_eq!(md, "$x + y$");
+    }
+
+    #[test]
+    fn test_html_to_markdown_standardized_callout() {
+        let html = r#"<div class="callout" data-callout="warning" data-callout-fold="-"><div class="callout-title">Caution</div><div class="callout-content"><p>Check the input.</p></div></div>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("> [!warning]-"), "Got: {md}");
+        assert!(md.contains("> Caution"), "Got: {md}");
+        assert!(md.contains("> Check the input."), "Got: {md}");
+    }
+
+    #[test]
+    fn test_html_to_markdown_bounds_nested_rich_conversion() {
+        let mut html = r#"<div class="callout" data-callout="note">"#.repeat(40);
+        html.push_str("Bounded payload");
+        html.push_str(&"</div>".repeat(40));
+
+        let md = html_to_markdown(&html);
+        assert!(md.contains("Bounded payload"), "Got: {md}");
+    }
+
+    #[test]
+    fn test_html_to_markdown_figures_details_and_tasks() {
+        let html = r#"<figure><img src="diagram.png" alt="Flow"><figcaption>System flow</figcaption></figure><details><summary>More</summary><p><input type="checkbox" checked>Complete</p></details>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("![Flow](diagram.png)"), "Got: {md}");
+        assert!(md.contains("System flow"), "Got: {md}");
+        assert!(md.contains("**More**"), "Got: {md}");
+        assert!(md.contains("[x] Complete"), "Got: {md}");
+    }
+
+    #[test]
     fn test_html_to_markdown_image_no_alt() {
         let html = r#"<img src="photo.jpg">"#;
         let md = html_to_markdown(html);
@@ -2158,7 +2764,17 @@ mod tests {
         </table>"#;
         let md = html_to_markdown(html);
         assert!(md.contains("| A | B |"), "Got: {}", md);
+        assert!(md.contains("| --- | --- |"), "Got: {}", md);
         assert!(md.contains("| C | D |"), "Got: {}", md);
+    }
+
+    #[test]
+    fn test_html_to_markdown_pads_uneven_table_rows() {
+        let html = r#"<table><tr><th colspan="2">Name</th></tr><tr><td>Ada</td><td>Lovelace</td></tr></table>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("| Name | |"), "Got: {md}");
+        assert!(md.contains("| --- | --- |"), "Got: {md}");
+        assert!(md.contains("| Ada | Lovelace |"), "Got: {md}");
     }
 
     #[test]

--- a/crates/fetchkit/src/fetchers/default.rs
+++ b/crates/fetchkit/src/fetchers/default.rs
@@ -8,17 +8,21 @@
 //! specialized fetchers.
 
 use crate::client::FetchOptions;
-use crate::content::{ContentProcessorInput, ContentProcessorRegistry};
+use crate::content::{
+    ContentFocus, ContentOutputFormat, ContentProcessorInput, ContentProcessorRegistry,
+    HtmlProcessor,
+};
 use crate::convert::{
-    classify_agent_resource, extract_headings, extract_metadata, extract_readable_content,
-    filter_excessive_newlines, html_to_markdown_with_base_url, html_to_text, is_html,
-    is_markdown_content_type, is_plain_text_content_type, strip_boilerplate,
+    classify_agent_resource, filter_excessive_newlines, is_html, is_markdown_content_type,
+    is_plain_text_content_type,
 };
 use crate::error::FetchError;
 use crate::fetchers::Fetcher;
 use crate::file_saver::FileSaver;
 use crate::transport::{BodyStream, TransportMethod, TransportRequest, TransportResponse};
-use crate::types::{AgentResource, FetchRequest, FetchResponse, HttpMethod, PageQuality};
+use crate::types::{
+    AgentResource, FetchRequest, FetchResponse, HttpMethod, PageMetadata, PageQuality,
+};
 use crate::DEFAULT_USER_AGENT;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -139,7 +143,10 @@ impl DefaultFetcher {
     }
 
     /// Create a default fetcher with a custom content processor registry.
-    pub fn with_content_processors(content_processors: ContentProcessorRegistry) -> Self {
+    pub fn with_content_processors(mut content_processors: ContentProcessorRegistry) -> Self {
+        if !content_processors.contains_named("html") {
+            content_processors.register(Box::new(HtmlProcessor::default()));
+        }
         Self { content_processors }
     }
 }
@@ -518,108 +525,22 @@ impl Fetcher for DefaultFetcher {
         }
 
         let parsed_final_url = Url::parse(&final_url).map_err(|_| FetchError::InvalidUrlScheme)?;
-        let content_processor = wants_markdown
-            .then(|| {
-                self.content_processors
-                    .find(&parsed_final_url, meta.content_type.as_deref())
-            })
-            .flatten();
-
-        // Content processors receive bytes only after the network path applies its
-        // timeout and decompressed-size limits.
-        if let Some(processor) = content_processor {
-            let processor_name = processor.name();
-            let (body, input_truncated) =
-                read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
-            let size = body.len() as u64;
-
-            if input_truncated {
-                let mut quality = binary_quality_signal();
-                quality.warnings.push("truncated".to_string());
-                return Ok(FetchResponse {
-                    url: final_url,
-                    status_code,
-                    content_type: meta.content_type,
-                    size: Some(size),
-                    last_modified: meta.last_modified,
-                    etag: meta.etag,
-                    filename: meta.filename,
-                    truncated: Some(true),
-                    redirect_chain,
-                    error: Some(format!(
-                        "Content processor {processor_name} cannot process a partial response body"
-                    )),
-                    quality: Some(quality),
-                    ..Default::default()
-                });
-            }
-
-            debug!(processor = processor_name, "Processing response content");
-            let processed = processor
-                .process(ContentProcessorInput {
-                    url: parsed_final_url,
-                    content_type: meta.content_type.clone(),
-                    body,
-                })
-                .await;
-
-            return match processed {
-                Ok(mut processed) => {
-                    let output_truncated = processed
-                        .content
-                        .as_mut()
-                        .map(|content| truncate_string_to_max_bytes(content, max_body_size))
-                        .unwrap_or(false);
-                    if output_truncated {
-                        if let Some(content) = &mut processed.content {
-                            content.push_str(TRUNCATION_MESSAGE);
-                        }
-                        if let Some(quality) = &mut processed.quality {
-                            push_warning(&mut quality.warnings, "truncated");
-                            quality.score = (quality.score - 0.2).max(0.0);
-                        }
-                    }
-                    let word_count = processed.content.as_deref().map(count_words);
-                    Ok(FetchResponse {
-                        url: final_url,
-                        status_code,
-                        content_type: meta.content_type,
-                        size: Some(size),
-                        last_modified: meta.last_modified,
-                        etag: meta.etag,
-                        filename: meta.filename,
-                        format: processed.format,
-                        content: processed.content,
-                        truncated: output_truncated.then_some(true),
-                        metadata: processed.metadata,
-                        quality: processed.quality,
-                        word_count,
-                        redirect_chain,
-                        error: processed.error,
-                        ..Default::default()
-                    })
-                }
-                Err(error) => Ok(FetchResponse {
-                    url: final_url,
-                    status_code,
-                    content_type: meta.content_type,
-                    size: Some(size),
-                    last_modified: meta.last_modified,
-                    etag: meta.etag,
-                    filename: meta.filename,
-                    redirect_chain,
-                    error: Some(format!(
-                        "Content processor {processor_name} failed: {error}"
-                    )),
-                    quality: Some(binary_quality_signal()),
-                    ..Default::default()
-                }),
-            };
-        }
+        let output_format = if wants_markdown {
+            ContentOutputFormat::Markdown
+        } else if wants_text {
+            ContentOutputFormat::Text
+        } else {
+            ContentOutputFormat::Raw
+        };
+        let metadata_processor = self.content_processors.find_for_output(
+            &parsed_final_url,
+            meta.content_type.as_deref(),
+            output_format,
+        );
 
         // Check for unsupported binary content
         if let Some(ref ct) = meta.content_type {
-            if is_binary_content_type(ct) {
+            if metadata_processor.is_none() && is_binary_content_type(ct) {
                 return Ok(FetchResponse {
                     url: final_url,
                     status_code,
@@ -641,7 +562,7 @@ impl Fetcher for DefaultFetcher {
 
         // THREAT[TM-DOS-001]: Read body with timeout and size limit
         // THREAT[TM-DOS-003]: Size limit also protects against compressed content bombs
-        let (body, truncated) =
+        let (body, input_truncated) =
             read_body_with_timeout(response, BODY_TIMEOUT, max_body_size).await?;
         let size = body.len() as u64;
 
@@ -661,24 +582,167 @@ impl Fetcher for DefaultFetcher {
         } else {
             None
         };
-        let truncated = truncated || rendered_truncated;
+        let truncated = input_truncated || rendered_truncated;
         let is_paywall = detect_paywall(&content);
-        let wants_main = request.wants_main_content();
-        let wants_readable = request.wants_readable_content();
-        let wants_agent = request.wants_agent_content();
 
-        // Extract structured metadata from HTML content (before boilerplate stripping)
-        let mut page_metadata = if is_html_content {
-            let mut pm = extract_metadata(&content);
-            pm.headings = extract_headings(&content);
-            if pm.is_empty() {
-                None
+        let content_processor = metadata_processor.or_else(|| {
+            if is_html_content {
+                self.content_processors.find_for_output(
+                    &parsed_final_url,
+                    Some("text/html"),
+                    output_format,
+                )
             } else {
-                Some(pm)
+                None
             }
-        } else {
-            None
-        };
+        });
+
+        if let Some(processor) = content_processor {
+            let processor_name = processor.name();
+            if truncated && !processor.accepts_truncated_input() {
+                let mut quality = binary_quality_signal();
+                quality.warnings.push("truncated".to_string());
+                return Ok(FetchResponse {
+                    url: final_url,
+                    status_code,
+                    content_type: meta.content_type,
+                    size: Some(size),
+                    last_modified: meta.last_modified,
+                    etag: meta.etag,
+                    filename: meta.filename,
+                    truncated: Some(true),
+                    redirect_chain,
+                    error: Some(format!(
+                        "Content processor {processor_name} cannot process a partial response body"
+                    )),
+                    quality: Some(quality),
+                    rendered_by,
+                    ..Default::default()
+                });
+            }
+
+            debug!(processor = processor_name, "Processing response content");
+            let processor_body = if rendered_by.is_some() {
+                Bytes::from(content.clone())
+            } else {
+                body.clone()
+            };
+            let processed = processor
+                .process(ContentProcessorInput {
+                    url: parsed_final_url,
+                    content_type: meta.content_type.clone(),
+                    body: processor_body,
+                    output_format,
+                    content_focus: ContentFocus::from_request(request.content_focus.as_deref()),
+                })
+                .await;
+
+            return match processed {
+                Ok(mut processed) => {
+                    let output_truncated = processed
+                        .content
+                        .as_mut()
+                        .map(|content| truncate_string_to_max_bytes(content, max_body_size))
+                        .unwrap_or(false);
+                    let truncated = truncated || output_truncated;
+                    let mut final_content = processed.content.take();
+
+                    let mut resources = resources_from_link_headers(&link_headers, &final_url);
+                    if is_html_content {
+                        if let Some(metadata) = &mut processed.metadata {
+                            normalize_html_resources(&mut metadata.agent_resources, &final_url);
+                            resources.append(&mut metadata.agent_resources);
+                        }
+                        if wants_markdown {
+                            resources.extend(probe_agent_resources(&final_url, options).await);
+                        }
+                    }
+                    deduplicate_resources(&mut resources);
+                    if !resources.is_empty() {
+                        if wants_markdown {
+                            if let Some(content) = &mut final_content {
+                                append_agent_resources(content, &resources);
+                            }
+                        }
+                        processed
+                            .metadata
+                            .get_or_insert_with(Default::default)
+                            .agent_resources = resources;
+                    }
+
+                    if truncated {
+                        if let Some(content) = &mut final_content {
+                            content.push_str(TRUNCATION_MESSAGE);
+                        }
+                    }
+                    let word_count = final_content.as_deref().map(count_words);
+                    let extraction_method = processed
+                        .metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.extraction_method.as_deref());
+                    let had_processor_quality = processed.quality.is_some();
+                    let mut quality = processed.quality.unwrap_or_else(|| {
+                        final_content
+                            .as_deref()
+                            .map_or_else(binary_quality_signal, |content| {
+                                compute_quality_signal(
+                                    content,
+                                    status_code,
+                                    truncated,
+                                    is_paywall,
+                                    extraction_method,
+                                    word_count.unwrap_or_default(),
+                                )
+                            })
+                    });
+                    if truncated {
+                        push_warning(&mut quality.warnings, "truncated");
+                        if had_processor_quality {
+                            quality.score = (quality.score - 0.2).max(0.0);
+                        }
+                    }
+
+                    Ok(FetchResponse {
+                        url: final_url,
+                        status_code,
+                        content_type: meta.content_type,
+                        size: Some(size),
+                        last_modified: meta.last_modified,
+                        etag: meta.etag,
+                        filename: meta.filename,
+                        format: processed.format,
+                        content: final_content,
+                        truncated: truncated.then_some(true),
+                        metadata: processed.metadata,
+                        quality: Some(quality),
+                        word_count,
+                        redirect_chain,
+                        error: processed.error,
+                        is_paywall: is_paywall.then_some(true),
+                        rendered_by,
+                        ..Default::default()
+                    })
+                }
+                Err(error) => Ok(FetchResponse {
+                    url: final_url,
+                    status_code,
+                    content_type: meta.content_type,
+                    size: Some(size),
+                    last_modified: meta.last_modified,
+                    etag: meta.etag,
+                    filename: meta.filename,
+                    redirect_chain,
+                    error: Some(format!(
+                        "Content processor {processor_name} failed: {error}"
+                    )),
+                    quality: Some(binary_quality_signal()),
+                    rendered_by,
+                    ..Default::default()
+                }),
+            };
+        }
+
+        let mut page_metadata: Option<PageMetadata> = None;
 
         let (format, final_content, extraction_method) =
             if is_markdown_content_type(&meta.content_type) && wants_markdown {
@@ -690,34 +754,7 @@ impl Fetcher for DefaultFetcher {
                 debug!("Content-type is plain text; skipping HTML conversion");
                 ("text".to_string(), content, Some("native_text"))
             } else if is_html_content {
-                let (html, method) = if wants_agent {
-                    if let Some(readable) = extract_readable_content(&content) {
-                        (readable, "agent_readable")
-                    } else {
-                        (strip_boilerplate(&content), "agent_main")
-                    }
-                } else if wants_readable {
-                    if let Some(readable) = extract_readable_content(&content) {
-                        (readable, "readable")
-                    } else {
-                        (strip_boilerplate(&content), "readable_fallback_main")
-                    }
-                } else if wants_main {
-                    (strip_boilerplate(&content), "main")
-                } else {
-                    (content, "full")
-                };
-                if wants_markdown {
-                    (
-                        "markdown".to_string(),
-                        html_to_markdown_with_base_url(&html, &final_url),
-                        Some(method),
-                    )
-                } else if wants_text {
-                    ("text".to_string(), html_to_text(&html), Some(method))
-                } else {
-                    ("raw".to_string(), html, Some(method))
-                }
+                ("raw".to_string(), content, Some("full"))
             } else {
                 ("raw".to_string(), content, Some("raw"))
             };
@@ -1451,10 +1488,38 @@ fn detect_paywall(html: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::content::{ContentProcessor, ContentProcessorError, ProcessedContent};
     use crate::dns::DnsPolicy;
     use crate::types::FetchRequest;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    struct BinaryIntegrityProcessor;
+
+    #[async_trait::async_trait]
+    impl ContentProcessor for BinaryIntegrityProcessor {
+        fn name(&self) -> &'static str {
+            "binary-integrity"
+        }
+
+        fn matches(&self, _url: &Url, content_type: Option<&str>) -> bool {
+            content_type == Some("application/pdf")
+        }
+
+        async fn process(
+            &self,
+            input: ContentProcessorInput,
+        ) -> Result<ProcessedContent, ContentProcessorError> {
+            if input.body.as_ref() != b"%PDF-\xff\0binary" {
+                return Err(ContentProcessorError("binary bytes changed".to_string()));
+            }
+            Ok(ProcessedContent {
+                format: Some("markdown".to_string()),
+                content: Some("binary bytes intact".to_string()),
+                ..Default::default()
+            })
+        }
+    }
 
     #[test]
     fn test_is_binary_content_type() {
@@ -1476,6 +1541,62 @@ mod tests {
         assert!(!is_binary_content_type("text/plain"));
         assert!(!is_binary_content_type("application/json"));
         assert!(!is_binary_content_type("application/javascript"));
+    }
+
+    #[tokio::test]
+    async fn content_processors_receive_original_binary_bytes() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/document"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(b"%PDF-\xff\0binary".to_vec())
+                    .insert_header("content-type", "application/pdf"),
+            )
+            .mount(&server)
+            .await;
+
+        let mut processors = ContentProcessorRegistry::new();
+        processors.register(Box::new(BinaryIntegrityProcessor));
+        let fetcher = DefaultFetcher::with_content_processors(processors);
+        let options = FetchOptions {
+            enable_markdown: true,
+            dns_policy: DnsPolicy::allow_all(),
+            ..Default::default()
+        };
+        let request = FetchRequest::new(format!("{}/document", server.uri())).as_markdown();
+        let response = fetcher.fetch(&request, &options).await.unwrap();
+
+        assert_eq!(response.content.as_deref(), Some("binary bytes intact"));
+        assert!(response.error.is_none(), "{:?}", response.error);
+    }
+
+    #[tokio::test]
+    async fn custom_binary_registry_retains_html_processing() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/article"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("<html><body><h1>Article</h1></body></html>")
+                    .insert_header("content-type", "text/html"),
+            )
+            .mount(&server)
+            .await;
+
+        let mut processors = ContentProcessorRegistry::new();
+        processors.register(Box::new(BinaryIntegrityProcessor));
+        let fetcher = DefaultFetcher::with_content_processors(processors);
+        let options = FetchOptions {
+            enable_markdown: true,
+            dns_policy: DnsPolicy::allow_all(),
+            ..Default::default()
+        };
+        let request = FetchRequest::new(format!("{}/article", server.uri())).as_markdown();
+        let response = fetcher.fetch(&request, &options).await.unwrap();
+
+        assert_eq!(response.format.as_deref(), Some("markdown"));
+        assert!(response.content.as_deref().unwrap().contains("# Article"));
     }
 
     #[test]

--- a/crates/fetchkit/src/lib.rs
+++ b/crates/fetchkit/src/lib.rs
@@ -57,7 +57,7 @@
 //! handle specific URL patterns. The [`FetcherRegistry`] dispatches
 //! requests to the appropriate fetcher based on URL matching.
 //! After retrieval, the [`ContentProcessorRegistry`] can transform bounded
-//! non-text response bytes based on media type.
+//! response bytes based on media type and requested output.
 //!
 //! Built-in fetchers:
 //! - [`ArXivFetcher`] - arXiv paper metadata and abstract
@@ -91,12 +91,13 @@ mod types;
 
 pub use client::{batch_fetch, batch_fetch_with_options, fetch, fetch_with_options, FetchOptions};
 pub use content::{
-    ContentProcessor, ContentProcessorError, ContentProcessorInput, ContentProcessorRegistry,
-    PdfProcessor, ProcessedContent,
+    ContentFocus, ContentOutputFormat, ContentProcessor, ContentProcessorError,
+    ContentProcessorInput, ContentProcessorRegistry, HtmlProcessor, PdfProcessor, ProcessedContent,
 };
 pub use convert::{
     extract_headings, extract_metadata, extract_readable_content, html_to_markdown,
     html_to_markdown_with_base_url, html_to_text, strip_boilerplate,
+    BuiltinHtmlToMarkdownConverter, HtmlToMarkdownConverter,
 };
 pub use dns::DnsPolicy;
 pub use error::{FetchError, ToolError};

--- a/knowledge/foundations/fetchers.md
+++ b/knowledge/foundations/fetchers.md
@@ -14,7 +14,7 @@ tags:
 
 Fetcher system enables specialized content retrieval based on URL patterns. A sibling content
 processor system transforms already-retrieved response bytes based on media type. This keeps
-network policy in fetchers while allowing formats such as PDF to produce structured responses
+network policy in fetchers while allowing formats such as HTML and PDF to produce structured responses
 optimized for LLM consumption.
 
 ## Requirements
@@ -48,13 +48,33 @@ Each content processor must implement:
 2. **`matches(url, content_type)`** - Returns true when response metadata identifies
    a supported format. Matching occurs before a body that would otherwise be rejected
    as binary is downloaded.
-3. **`process(input)`** - Async processing of final URL, Content-Type, and body bytes.
+3. **`supports_output(output_format)`** - Returns whether the processor supports
+   Markdown, text, or focused raw output. Markdown-only is the default.
+4. **`accepts_truncated_input()`** - Returns whether partial bounded input is useful.
+   False is the default.
+5. **`process(input)`** - Async processing of final URL, Content-Type, body bytes,
+   requested output, and content focus.
    Input bytes have already passed fetchkit's timeout and decompressed-size limits.
 
 `ContentProcessorRegistry` is ordered and uses the first matching processor. It provides
-`new()`, `with_defaults()`, `register()`, and `find()`. Processors do not perform network
+`new()`, `with_defaults()`, `register()`, `find()`, and `find_for_output()`. Processors do not perform network
 requests. `FetcherRegistry::with_content_processors()` retains the built-in fetchers while
 allowing callers to replace the default content processor registry.
+
+#### HtmlProcessor
+
+- Matches `text/html` and `application/xhtml+xml`; body sniffing can dispatch HTML
+  served without an accurate Content-Type after bounded download.
+- Extracts metadata before applying `full`, `main`, `readable`, or `agent` focus.
+- Produces Markdown through a replaceable `HtmlToMarkdownConverter`, plain text,
+  or focused raw HTML.
+- Uses `BuiltinHtmlToMarkdownConverter` by default.
+- `DefaultFetcher::with_content_processors()` appends the built-in HTML processor
+  when the supplied registry has no processor named `html`, preserving HTML
+  conversion for registries that only customize binary formats. Register an
+  `HtmlProcessor` with a custom converter to replace it.
+- Accepts truncated input and returns useful partial content with truncation signals.
+- Runs after optional rendering; it performs no rendering or network requests.
 
 #### PdfProcessor
 
@@ -76,7 +96,7 @@ allowing callers to replace the default content processor registry.
 - Behavior: Standard HTTP fetch with HTML conversion support
 - Features:
   - GET and HEAD methods
-  - HTML to markdown/text conversion (when enabled)
+  - HTML processor dispatch for markdown/text conversion (when enabled)
   - Content processor dispatch before unsupported binary detection
   - Binary content detection (returns metadata only when no processor matches)
   - Timeout handling with partial content support

--- a/knowledge/foundations/tool-contract.md
+++ b/knowledge/foundations/tool-contract.md
@@ -304,6 +304,10 @@ By default, Fetchkit blocks connections to private/reserved IP ranges:
 
 #### HTML-to-Markdown
 
+- HTML extraction and conversion runs through the built-in `HtmlProcessor` after
+  retrieval limits and optional rendering. The processor accepts `full`, `main`,
+  `readable`, and `agent` content focus and delegates Markdown serialization to
+  `BuiltinHtmlToMarkdownConverter` by default.
 - Fetched HTML converted to markdown resolves relative anchor `href` and image `src`
   values against the final response URL after redirects.
 - Fragment-only links (`#section`) and non-HTTP navigation schemes such as `mailto:`,
@@ -383,7 +387,7 @@ Content is HTML if:
 
 ### HTML to Markdown
 
-- Strip content inside: `script`, `style`, `noscript`, `iframe`, `svg`.
+- Strip content inside: `head`, `script`, `style`, `noscript`, `template`, `iframe`, `svg`.
 - `h1`..`h6` -> `#`..`######`.
 - Block elements (`p`, `div`, `section`, `article`, `main`, `header`, `footer`):
   - On close, add blank line.
@@ -392,15 +396,26 @@ Content is HTML if:
   - Track depth for `ul`/`ol`.
   - `li` adds newline and `- ` with two-space indentation per depth.
 - `strong`/`b` -> `**`, `em`/`i` -> `*`.
-- `pre` -> fenced code block, inline `code` -> backticks (not inside pre).
+- `del`/`s`/`strike` -> `~~`, `mark` -> `==`.
+- `pre` -> collision-safe fenced code block; inline `code` uses a delimiter longer
+  than any contained backtick run.
 - `blockquote` -> `> ` prefix.
-- `a href="..."` uses naive inline format: `](href)` on open tag (no link text tracking).
+- Links and images preserve optional titles. Destinations containing spaces or
+  parentheses use angle-bracket Markdown destinations.
+- Images prefer the highest-resolution `srcset` candidate and resolve it against
+  the final response URL.
+- Tables always include a delimiter row, pad uneven rows, preserve inline cell
+  formatting, and escape literal pipes.
+- Standardized footnote references/definitions use `[^id]` syntax and omit backlinks.
+- Math with `data-latex`, `alttext`, or TeX annotations uses `$...$`/`$$...$$`.
+- Standardized callouts use `> [!type]`, including fold markers.
+- Figures, captions, details/summary, and checkbox inputs retain readable structure.
 - Decode entities: `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`, `&#39;`, `&nbsp;`,
   `&mdash;`, `&ndash;`, `&copy;`, `&reg;`.
 
 ### HTML to Text
 
-- Strip content inside: `script`, `style`, `noscript`, `iframe`, `svg`.
+- Strip content inside: `head`, `script`, `style`, `noscript`, `template`, `iframe`, `svg`.
 - Newline on: `p`, `div`, `br`, `h1`..`h6`, `li`, `tr`.
 - Same entity decoding as markdown.
 - Normalize whitespace via `clean_whitespace` (collapse runs, trim, keep max 2 newlines).

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,5 +2,6 @@
 
 ## 2026-08-08
 
+* **HTML processing**: Routed HTML extraction and Markdown/text conversion through the content processor registry, added a replaceable native converter, expanded structural fidelity for code, tables, footnotes, math, callouts, and related rich content, and bounded nested conversion depth.
 * **Migration**: Replaced the unindexed specification directory with an OKF v0.2 bundle organized by foundations, integrations, security, and operations.
 * **Process**: Added a maintenance contract and automated conformance checks so durable engineering knowledge changes with the implementation.

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -351,21 +351,21 @@ which could contain hostnames or URL details.
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
 | TM-CONV-001 | Script injection in converted markdown | Low | `<script>` tags stripped during HTML-to-markdown conversion | MITIGATED |
-| TM-CONV-002 | Excessive memory from deeply nested HTML | Medium | No recursion depth limit in HTML parser | **ACCEPTED** |
+| TM-CONV-002 | Excessive memory from deeply nested HTML | Medium | Bounded body plus an 8-level nested conversion limit | MITIGATED |
 | TM-CONV-003 | Markdown injection (crafted HTML producing executable markdown) | Low | Fetchkit produces markdown text; execution depends on downstream consumer | **BY DESIGN** |
 | TM-CONV-004 | Entity decoding producing unexpected characters | Low | Limited entity set decoded; no arbitrary numeric entity expansion | MITIGATED |
 
 ### Mitigation Details
 
 **TM-CONV-001 — Script stripping (MITIGATED):**
-The HTML converter skips content inside `script`, `style`, `noscript`, `iframe`,
-and `svg` tags, preventing script injection into the converted output.
+The HTML converter skips content inside `head`, `script`, `style`, `noscript`,
+`template`, `iframe`, and `svg` tags, preventing script injection into the
+converted output.
 
-**TM-CONV-002 — Deeply nested HTML (ACCEPTED):**
-The HTML parser is character-based and iterative (not recursive), so stack
-overflow from deep nesting is unlikely. However, deeply nested structures could
-produce large output. This is accepted as the body size limit (TM-DOS-001)
-provides upstream protection.
+**TM-CONV-002 — Deeply nested HTML (MITIGATED):**
+The main HTML parser is character-based and iterative. Rich table cells and
+callouts recursively reuse conversion, capped at 8 levels with plain-text
+fallback. The body size limit (TM-DOS-001) also bounds input and output growth.
 
 ## 7. Bot Authentication (TM-AUTH)
 
@@ -426,7 +426,6 @@ None — all previously open threats have been mitigated.
 | TM-DOS-005 | DNS delay | System resolver; typical behavior |
 | TM-LEAK-002 | DNS error detail | Hostname visible but not internal IPs |
 | TM-LEAK-005 | Timing channels | Low risk; timeout masks some signal |
-| TM-CONV-002 | Deep HTML nesting | Iterative parser; upstream size limits |
 | TM-AUTH-001 | Signing key in memory | Same as any in-process secret; OS protections apply |
 
 ### Caller Responsibilities
@@ -458,7 +457,7 @@ None — all previously open threats have been mitigated.
 | First-byte timeout | TM-DOS | 1-second connect+response timeout |
 | Body timeout | TM-DOS | 30-second streaming body timeout |
 | Body size limit | TM-DOS | Configurable `max_body_size` (default 10 MB) |
-| Script tag stripping | TM-CONV | Skip `script`/`style`/`noscript`/`iframe`/`svg` |
+| Script tag stripping | TM-CONV | Skip `head`/`script`/`style`/`noscript`/`template`/`iframe`/`svg` |
 | Binary detection | TM-CONV | Content-Type prefix matching |
 | New client per request | TM-NET | No connection pool state leakage |
 | Pluggable transport keeps policy in fetchkit | TM-SSRF, TM-NET | `HttpTransport` only performs the socket send; DNS policy (resolve-then-check), redirect following, and proxy suppression stay in fetchkit. `TransportRequest.pinned_addrs` (from `DnsPolicy`) constrains a custom transport to fetchkit-validated addresses; the default `ReqwestTransport` enforces this via `resolve_to_addrs()` |


### PR DESCRIPTION
## What changed

Route bounded HTML extraction and Markdown/text/raw conversion through the content processor registry. Add a replaceable native HTML-to-Markdown converter and preserve richer structures including collision-safe code, tables, footnotes, math, callouts, figures, and task checkboxes. Conversion behavior adapted from Defuddle is credited in source and its MIT notice is preserved.

## Why

HTML and PDF post-download extraction should share one processor pipeline while keeping format conversion replaceable. The richer native converter closes fidelity gaps with Defuddle without adding a JavaScript runtime dependency.

## Before / After

Before: HTML conversion was hardwired into the default fetcher and custom processor registries only handled Markdown-oriented binary extraction.

After: `HtmlProcessor` handles Markdown, text, and focused raw HTML through the registry; callers may inject an `HtmlToMarkdownConverter`. CLI smoke output for `fetchkit fetch https://example.com --content-focus main`:

```markdown
# Example Domain

This domain is for use in documentation examples without needing permission. Avoid use in operations.

[Learn more](https://iana.org/domains/example)
```

The library `fetch_urls` smoke suite reported 6 passed, 0 failed. Workspace tests passed with 557 tests and 2 network tests ignored.

## Risk

- Medium
- `ContentProcessorInput` gains required `output_format` and `content_focus` fields, which breaks exhaustive external struct construction.
- HTML conversion output changes for rich structures and document-head stripping.
- Conversion input remains body-size bounded; recursive rich conversion is capped at eight levels.

### Checklist

- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
- [x] Knowledge is up to date and not in conflict